### PR TITLE
Fix problem with dependency name

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -20,7 +20,7 @@ object BuildPlugins {
 
 object Libraries {
     val annotations = "org.jetbrains:annotations:${Versions.annotations}"
-    val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}}"
+    val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
     val kxml = "net.sf.kxml:kxml2:${Versions.kxml}"
     val ktorNetwork = "io.ktor:ktor-network:${Versions.ktor}"
     val logging = "io.github.microutils:kotlin-logging:${Versions.logging}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,7 +22,7 @@ object Libraries {
     val annotations = "org.jetbrains:annotations:${Versions.annotations}"
     val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
     val kxml = "net.sf.kxml:kxml2:${Versions.kxml}"
-    val ktorNetwork = "io.ktor:ktor-network:${Versions.ktor}"
+    val ktorNetwork = "io.ktor:ktor-network-jvm:${Versions.ktor}"
     val logging = "io.github.microutils:kotlin-logging:${Versions.logging}"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Aug 04 13:21:59 AEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Last build failed with `Could not find org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9}.`
Delete extra } from dependencies