### PR TITLE
Feature/am proto

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ dependencies {
     implementation(Libraries.coroutines)
     implementation(Libraries.ktorNetwork)
     implementation(Libraries.logging)
+    implementation(Libraries.pdbank)
 
     testImplementation(TestLibraries.assertk)
     testImplementation(TestLibraries.junit)

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -12,6 +12,7 @@ object Versions {
     val junit = "4.12"
     val imageComparison = "4.3.0"
     val dokka = kotlin
+    val pdbank = "0.9.1"
 }
 
 object BuildPlugins {
@@ -24,6 +25,7 @@ object Libraries {
     val kxml = "net.sf.kxml:kxml2:${Versions.kxml}"
     val ktorNetwork = "io.ktor:ktor-network-jvm:${Versions.ktor}"
     val logging = "io.github.microutils:kotlin-logging:${Versions.logging}"
+    val pdbank = "pro.streem.pbandk:pbandk-runtime-jvm:${Versions.pdbank}"
 }
 
 object TestLibraries {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Aug 04 13:21:59 AEST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/integrationTest/kotlin/com/malinskiy/adam/integration/TestRunnerE2ETest.kt
+++ b/src/integrationTest/kotlin/com/malinskiy/adam/integration/TestRunnerE2ETest.kt
@@ -122,7 +122,7 @@ class TestRunnerE2ETest {
             }).isTrue()
 
             assertThat(events.any {
-                it is TestEnded && it.id.className == "com.example.AbstractFailingTest" && it.id.testName == "testAlwaysFailing" && it.metrics[Const.TEST_LOGCAT_METRIC]!!.isNotEmpty()
+                it is TestEnded && it.id.className == "com.example.AbstractFailingTest" && it.id.testName == "testAlwaysFailing"
             }).isTrue()
 
             assertThat(events.any {

--- a/src/integrationTest/kotlin/com/malinskiy/adam/rule/AdbDeviceRule.kt
+++ b/src/integrationTest/kotlin/com/malinskiy/adam/rule/AdbDeviceRule.kt
@@ -46,6 +46,7 @@ class AdbDeviceRule(val deviceType: DeviceType = DeviceType.ANY, vararg val requ
     lateinit var deviceSerial: String
     lateinit var supportedFeatures: List<Feature>
     lateinit var lineSeparator: String
+    
     val adb = AndroidDebugBridgeClientFactory().build()
     val initTimeout = Duration.ofSeconds(10)
 

--- a/src/main/kotlin/com/malinskiy/adam/AndroidDebugBridgeClient.kt
+++ b/src/main/kotlin/com/malinskiy/adam/AndroidDebugBridgeClient.kt
@@ -30,16 +30,14 @@ import com.malinskiy.adam.transport.AndroidReadChannel
 import com.malinskiy.adam.transport.AndroidWriteChannel
 import com.malinskiy.adam.transport.KtorSocketFactory
 import com.malinskiy.adam.transport.SocketFactory
-import io.ktor.network.sockets.openReadChannel
-import io.ktor.network.sockets.openWriteChannel
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.ByteWriteChannel
-import io.ktor.utils.io.cancel
-import io.ktor.utils.io.close
+import io.ktor.network.sockets.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.withContext
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.time.Duration
@@ -116,7 +114,9 @@ class AndroidDebugBridgeClient(
                     }
                 } finally {
                     try {
-                        request.close(channel)
+                        withContext(NonCancellable) {
+                            request.close(channel)
+                        }
                         writeChannel?.close()
                         readChannel.cancel()
                     } catch (e: Exception) {

--- a/src/main/kotlin/com/malinskiy/adam/Const.kt
+++ b/src/main/kotlin/com/malinskiy/adam/Const.kt
@@ -28,6 +28,10 @@ object Const {
     const val MAX_PACKET_LENGTH = 16384
     const val MAX_FILE_PACKET_LENGTH = 64 * 1024
 
+    const val MAX_PROTOBUF_LOGCAT_LENGTH = 10_000
+    const val MAX_PROTOBUF_PACKET_LENGTH = 10 * 1024 * 1024L //10Mb
+    const val TEST_LOGCAT_METRIC = "com.malinskiy.adam.logcat"
+
     const val ANDROID_FILE_SEPARATOR = "/"
     val SYNC_IGNORED_FILES = setOf(".", "..")
 

--- a/src/main/kotlin/com/malinskiy/adam/extension/ByteBuffer.kt
+++ b/src/main/kotlin/com/malinskiy/adam/extension/ByteBuffer.kt
@@ -26,3 +26,4 @@ import java.nio.ByteBuffer
  */
 fun ByteBuffer.compatRewind() = ((this as Buffer).rewind() as ByteBuffer)
 fun ByteBuffer.compatLimit(newLimit: Int) = ((this as Buffer).limit(newLimit) as ByteBuffer)
+fun ByteBuffer.compatPosition(newLimit: Int) = ((this as Buffer).position(newLimit) as ByteBuffer)

--- a/src/main/kotlin/com/malinskiy/adam/request/AsyncChannelRequest.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/AsyncChannelRequest.kt
@@ -44,5 +44,5 @@ abstract class AsyncChannelRequest<T : Any?, I : Any?>(
      * Optionally send a message
      * The transport connection is not available at this point
      */
-    open fun close(channel: SendChannel<T>) = Unit
+    open suspend fun close(channel: SendChannel<T>) = Unit
 }

--- a/src/main/kotlin/com/malinskiy/adam/request/sync/base/BasePullFileRequest.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/sync/base/BasePullFileRequest.kt
@@ -25,8 +25,8 @@ import com.malinskiy.adam.request.ValidationResponse
 import com.malinskiy.adam.request.sync.v1.StatFileRequest
 import com.malinskiy.adam.transport.AndroidReadChannel
 import com.malinskiy.adam.transport.AndroidWriteChannel
-import io.ktor.util.cio.writeChannel
-import io.ktor.utils.io.close
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.SendChannel
 import java.io.File
@@ -97,7 +97,7 @@ abstract class BasePullFileRequest(
         }
     }
 
-    override fun close(channel: SendChannel<Double>) {
+    override suspend fun close(channel: SendChannel<Double>) {
         fileWriteChannel.close()
     }
 

--- a/src/main/kotlin/com/malinskiy/adam/request/sync/base/BasePushFileRequest.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/sync/base/BasePushFileRequest.kt
@@ -23,8 +23,8 @@ import com.malinskiy.adam.request.AsyncChannelRequest
 import com.malinskiy.adam.request.ValidationResponse
 import com.malinskiy.adam.transport.AndroidReadChannel
 import com.malinskiy.adam.transport.AndroidWriteChannel
-import io.ktor.util.cio.readChannel
-import io.ktor.utils.io.cancel
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.SendChannel
 import java.io.File
@@ -73,7 +73,7 @@ abstract class BasePushFileRequest(
 
     override fun serialize() = createBaseRequest("sync:")
 
-    override fun close(channel: SendChannel<Double>) {
+    override suspend fun close(channel: SendChannel<Double>) {
         fileReadChannel.cancel()
     }
 

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/TestEvent.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/TestEvent.kt
@@ -27,3 +27,4 @@ data class TestEnded(val id: TestIdentifier, val metrics: Map<String, String>) :
 data class TestRunFailed(val error: String) : TestEvent()
 data class TestRunStopped(val elapsedTimeMillis: Long) : TestEvent()
 data class TestRunEnded(val elapsedTimeMillis: Long, val metrics: Map<String, String>) : TestEvent()
+data class TestLogcat(val id: TestIdentifier, val log: String)

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequest.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequest.kt
@@ -26,7 +26,18 @@ import com.malinskiy.adam.transport.AndroidWriteChannel
 import kotlinx.coroutines.channels.SendChannel
 
 /**
+ * @param outputLogPath if specified with protobuf then write output as protobuf to a file (machine
+ * readable). If path is not specified, default directory and file name will
+ * be used: /sdcard/instrument-logs/log-yyyyMMdd-hhmmss-SSS.instrumentation_data_proto
+ *
  * @param protobuf API 26+
+ *
+ * @param noIsolatedStorage don't use isolated storage sandbox and mount full external storage
+ * @param noHiddenApiChecks disable restrictions on use of hidden API
+ * @param noWindowAnimations turn off window animations while running
+ * @param userId Specify user instrumentation runs in; current user if not specified
+ * @param abi Launch the instrumented process with the selected ABI. This assumes that the process supports the selected ABI.
+ * @param profilingOutputPath write profiling data to <FILE>
  *
  * @see https://android.googlesource.com/platform/frameworks/base/+/master/cmds/am/src/com/android/commands/am/Am.java#155
  */
@@ -36,11 +47,12 @@ class TestRunnerRequest(
     private val runnerClass: String = "android.support.test.runner.AndroidJUnitRunner",
     private val noHiddenApiChecks: Boolean = false,
     private val noWindowAnimations: Boolean = false,
+    private val noIsolatedStorage: Boolean = false,
     private val userId: Int? = null,
     private val abi: String? = null,
     private val profilingOutputPath: String? = null,
     private val outputLogPath: String? = null,
-    private val protobuf: Boolean = false
+    private val protobuf: Boolean = false,
 ) : AsyncChannelRequest<List<TestEvent>, Unit>() {
     private val buffer = ByteArray(Const.MAX_PACKET_LENGTH)
 
@@ -81,6 +93,10 @@ class TestRunnerRequest(
             append(" --no-window-animation")
         }
 
+        if (noIsolatedStorage) {
+            append(" --no-isolated-storage")
+        }
+
         if (userId != null) {
             append(" --user $userId")
         }
@@ -93,12 +109,12 @@ class TestRunnerRequest(
             append(" -p $profilingOutputPath")
         }
 
-        if (outputLogPath != null) {
-            append(" -f $outputLogPath")
-        }
-
         if (protobuf) {
             append(" -m")
+        }
+
+        if (outputLogPath != null) {
+            append(" -f $outputLogPath")
         }
 
         append(instrumentOptions.toString())

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/SessionResultCode.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/SessionResultCode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Anton Malinskiy
+ * Copyright (C) 2021 Anton Malinskiy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.malinskiy.adam.request.testrunner
+package com.malinskiy.adam.request.testrunner.model
 
-data class TestIdentifier(
-    val className: String,
-    val testName: String
-)
+enum class SessionResultCode(val value: Int) {
+    FINISHED(-1),
+    ERROR(0)
+}

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/State.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/State.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Anton Malinskiy
+ * Copyright (C) 2021 Anton Malinskiy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package com.malinskiy.adam.request.testrunner
+package com.malinskiy.adam.request.testrunner.model
 
-data class TestIdentifier(
-    val className: String,
-    val testName: String
-)
+sealed class State(val terminal: Boolean)
+
+object NotStarted : State(false)
+object Running : State(false)
+object Finished : State(true)
+object Cancelled : State(true)

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/Status.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/Status.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.request.testrunner.model
+
+enum class Status(val value: Int) {
+    SUCCESS(0),
+    START(1),
+    IN_PROGRESS(2),
+
+    /**
+     * JUnit3 runner code, treated as FAILURE
+     */
+    ERROR(-1),
+    FAILURE(-2),
+    IGNORED(-3),
+    ASSUMPTION_FAILURE(-4),
+    UNKNOWN(6666);
+
+    fun isTerminal() = value < 0
+
+    companion object {
+        fun valueOf(value: Int?): Status {
+            return when (value) {
+                0 -> SUCCESS
+                1 -> START
+                2 -> IN_PROGRESS
+                -1 -> ERROR
+                -2 -> FAILURE
+                -3 -> IGNORED
+                -4 -> ASSUMPTION_FAILURE
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/StatusKey.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/StatusKey.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.request.testrunner.model
+
+enum class StatusKey(val value: String) {
+    TEST("test"),
+    CLASS("class"),
+    STACK("stack"),
+    NUMTESTS("numtests"),
+    ERROR("Error"),
+    SHORTMSG("shortMsg"),
+    STREAM("stream"),
+    CURRENT("current"),
+    ID("id"),
+    UNKNOWN("");
+
+    companion object {
+        fun of(value: String?) = when (value) {
+            "test" -> TEST
+            "class" -> CLASS
+            "stack" -> STACK
+            "numtests" -> NUMTESTS
+            "Error" -> ERROR
+            "shortMsg" -> SHORTMSG
+            "stream" -> STREAM
+            "current" -> CURRENT
+            "id" -> ID
+            else -> UNKNOWN
+        }
+    }
+}

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/TestStatusAggregator.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/TestStatusAggregator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Anton Malinskiy
+ * Copyright (C) 2021 Anton Malinskiy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package com.malinskiy.adam.request.testrunner
+package com.malinskiy.adam.request.testrunner.model
 
-data class TestIdentifier(
-    val className: String,
-    val testName: String
+import com.malinskiy.adam.Const
+
+data class TestStatusAggregator(
+    var statusCode: Status,
+    val logcatBuilder: StringBuilder = StringBuilder(Const.MAX_PROTOBUF_LOGCAT_LENGTH),
+    val metrics: MutableMap<String, String> = mutableMapOf()
 )

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/TokenType.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/model/TokenType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Anton Malinskiy
+ * Copyright (C) 2021 Anton Malinskiy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package com.malinskiy.adam.request.testrunner
+package com.malinskiy.adam.request.testrunner.model
 
-data class TestIdentifier(
-    val className: String,
-    val testName: String
-)
+enum class TokenType {
+    INSTRUMENTATION_STATUS,
+    INSTRUMENTATION_STATUS_CODE,
+    INSTRUMENTATION_RESULT,
+    INSTRUMENTATION_CODE,
+    INSTRUMENTATION_FAILED
+}

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/proto/instrumentation-data.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/proto/instrumentation-data.kt
@@ -1,0 +1,462 @@
+@file:OptIn(pbandk.PublicForGeneratedCode::class)
+
+package com.malinskiy.adam.request.testrunner.proto
+
+sealed class SessionStatusCode(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
+    override fun equals(other: Any?) = other is SessionStatusCode && other.value == value
+    override fun hashCode() = value.hashCode()
+    override fun toString() = "SessionStatusCode.${name ?: "UNRECOGNIZED"}(value=$value)"
+
+    object SESSION_FINISHED : SessionStatusCode(0, "SESSION_FINISHED")
+    object SESSION_ABORTED : SessionStatusCode(1, "SESSION_ABORTED")
+    class UNRECOGNIZED(value: Int) : SessionStatusCode(value)
+
+    companion object : pbandk.Message.Enum.Companion<SessionStatusCode> {
+        val values: List<SessionStatusCode> by lazy { listOf(SESSION_FINISHED, SESSION_ABORTED) }
+        override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
+        override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No SessionStatusCode with name: $name")
+    }
+}
+
+data class ResultsBundleEntry(
+    val key: String? = null,
+    val valueString: String? = null,
+    val valueInt: Int? = null,
+    val valueFloat: Float? = null,
+    val valueDouble: Double? = null,
+    val valueLong: Long? = null,
+    val valueBundle: ResultsBundle? = null,
+    val valueBytes: pbandk.ByteArr? = null,
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
+    override val descriptor get() = Companion.descriptor
+    override val protoSize by lazy { super.protoSize }
+    companion object : pbandk.Message.Companion<ResultsBundleEntry> {
+        val defaultInstance by lazy { ResultsBundleEntry() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = ResultsBundleEntry.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<ResultsBundleEntry> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<ResultsBundleEntry, *>>(8).apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "key",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                        jsonName = "key",
+                        value = ResultsBundleEntry::key
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_string",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                        jsonName = "valueString",
+                        value = ResultsBundleEntry::valueString
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_int",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true),
+                        jsonName = "valueInt",
+                        value = ResultsBundleEntry::valueInt
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_float",
+                        number = 4,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
+                        jsonName = "valueFloat",
+                        value = ResultsBundleEntry::valueFloat
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_double",
+                        number = 5,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
+                        jsonName = "valueDouble",
+                        value = ResultsBundleEntry::valueDouble
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_long",
+                        number = 6,
+                        type = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true),
+                        jsonName = "valueLong",
+                        value = ResultsBundleEntry::valueLong
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_bundle",
+                        number = 7,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = ResultsBundle.Companion),
+                        jsonName = "valueBundle",
+                        value = ResultsBundleEntry::valueBundle
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "value_bytes",
+                        number = 8,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
+                        jsonName = "valueBytes",
+                        value = ResultsBundleEntry::valueBytes
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                messageClass = ResultsBundleEntry::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+data class ResultsBundle(
+    val entries: List<ResultsBundleEntry> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
+    override val descriptor get() = Companion.descriptor
+    override val protoSize by lazy { super.protoSize }
+    companion object : pbandk.Message.Companion<ResultsBundle> {
+        val defaultInstance by lazy { ResultsBundle() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = ResultsBundle.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<ResultsBundle> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<ResultsBundle, *>>(1).apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "entries",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Repeated<ResultsBundleEntry>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = ResultsBundleEntry.Companion)),
+                        jsonName = "entries",
+                        value = ResultsBundle::entries
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                messageClass = ResultsBundle::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+data class TestStatus(
+    val resultCode: Int? = null,
+    val results: ResultsBundle? = null,
+    val logcat: String? = null,
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
+    override val descriptor get() = Companion.descriptor
+    override val protoSize by lazy { super.protoSize }
+    companion object : pbandk.Message.Companion<TestStatus> {
+        val defaultInstance by lazy { TestStatus() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = TestStatus.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<TestStatus> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<TestStatus, *>>(3).apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "result_code",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true),
+                        jsonName = "resultCode",
+                        value = TestStatus::resultCode
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "results",
+                        number = 4,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = ResultsBundle.Companion),
+                        jsonName = "results",
+                        value = TestStatus::results
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "logcat",
+                        number = 5,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                        jsonName = "logcat",
+                        value = TestStatus::logcat
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                messageClass = TestStatus::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+data class SessionStatus(
+    val statusCode: SessionStatusCode? = null,
+    val errorText: String? = null,
+    val resultCode: Int? = null,
+    val results: ResultsBundle? = null,
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
+    override val descriptor get() = Companion.descriptor
+    override val protoSize by lazy { super.protoSize }
+    companion object : pbandk.Message.Companion<SessionStatus> {
+        val defaultInstance by lazy { SessionStatus() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = SessionStatus.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<SessionStatus> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<SessionStatus, *>>(4).apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "status_code",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = SessionStatusCode.Companion, hasPresence = true),
+                        jsonName = "statusCode",
+                        value = SessionStatus::statusCode
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "error_text",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                        jsonName = "errorText",
+                        value = SessionStatus::errorText
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "result_code",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true),
+                        jsonName = "resultCode",
+                        value = SessionStatus::resultCode
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "results",
+                        number = 4,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = ResultsBundle.Companion),
+                        jsonName = "results",
+                        value = SessionStatus::results
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                messageClass = SessionStatus::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+data class Session(
+    val testStatus: List<TestStatus> = emptyList(),
+    val sessionStatus: SessionStatus? = null,
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
+    override val descriptor get() = Companion.descriptor
+    override val protoSize by lazy { super.protoSize }
+    companion object : pbandk.Message.Companion<Session> {
+        val defaultInstance by lazy { Session() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = Session.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<Session> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<Session, *>>(2).apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "test_status",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Repeated<TestStatus>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = TestStatus.Companion)),
+                        jsonName = "testStatus",
+                        value = Session::testStatus
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "session_status",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = SessionStatus.Companion),
+                        jsonName = "sessionStatus",
+                        value = Session::sessionStatus
+                    )
+                )
+            }
+            pbandk.MessageDescriptor(
+                messageClass = Session::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+    }
+}
+
+fun ResultsBundleEntry?.orDefault() = this ?: ResultsBundleEntry.defaultInstance
+
+private fun ResultsBundleEntry.protoMergeImpl(plus: pbandk.Message?): ResultsBundleEntry = (plus as? ResultsBundleEntry)?.copy(
+    key = plus.key ?: key,
+    valueString = plus.valueString ?: valueString,
+    valueInt = plus.valueInt ?: valueInt,
+    valueFloat = plus.valueFloat ?: valueFloat,
+    valueDouble = plus.valueDouble ?: valueDouble,
+    valueLong = plus.valueLong ?: valueLong,
+    valueBundle = valueBundle?.plus(plus.valueBundle) ?: plus.valueBundle,
+    valueBytes = plus.valueBytes ?: valueBytes,
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun ResultsBundleEntry.Companion.decodeWithImpl(u: pbandk.MessageDecoder): ResultsBundleEntry {
+    var key: String? = null
+    var valueString: String? = null
+    var valueInt: Int? = null
+    var valueFloat: Float? = null
+    var valueDouble: Double? = null
+    var valueLong: Long? = null
+    var valueBundle: ResultsBundle? = null
+    var valueBytes: pbandk.ByteArr? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> key = _fieldValue as String
+            2 -> valueString = _fieldValue as String
+            3 -> valueInt = _fieldValue as Int
+            4 -> valueFloat = _fieldValue as Float
+            5 -> valueDouble = _fieldValue as Double
+            6 -> valueLong = _fieldValue as Long
+            7 -> valueBundle = _fieldValue as ResultsBundle
+            8 -> valueBytes = _fieldValue as pbandk.ByteArr
+        }
+    }
+    return ResultsBundleEntry(key, valueString, valueInt, valueFloat,
+        valueDouble, valueLong, valueBundle, valueBytes, unknownFields)
+}
+
+fun ResultsBundle?.orDefault() = this ?: ResultsBundle.defaultInstance
+
+private fun ResultsBundle.protoMergeImpl(plus: pbandk.Message?): ResultsBundle = (plus as? ResultsBundle)?.copy(
+    entries = entries + plus.entries,
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun ResultsBundle.Companion.decodeWithImpl(u: pbandk.MessageDecoder): ResultsBundle {
+    var entries: pbandk.ListWithSize.Builder<ResultsBundleEntry>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> entries = (entries ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<ResultsBundleEntry> }
+        }
+    }
+    return ResultsBundle(pbandk.ListWithSize.Builder.fixed(entries), unknownFields)
+}
+
+fun TestStatus?.orDefault() = this ?: TestStatus.defaultInstance
+
+private fun TestStatus.protoMergeImpl(plus: pbandk.Message?): TestStatus = (plus as? TestStatus)?.copy(
+    resultCode = plus.resultCode ?: resultCode,
+    results = results?.plus(plus.results) ?: plus.results,
+    logcat = plus.logcat ?: logcat,
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun TestStatus.Companion.decodeWithImpl(u: pbandk.MessageDecoder): TestStatus {
+    var resultCode: Int? = null
+    var results: ResultsBundle? = null
+    var logcat: String? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            3 -> resultCode = _fieldValue as Int
+            4 -> results = _fieldValue as ResultsBundle
+            5 -> logcat = _fieldValue as String
+        }
+    }
+    return TestStatus(resultCode, results, logcat, unknownFields)
+}
+
+fun SessionStatus?.orDefault() = this ?: SessionStatus.defaultInstance
+
+private fun SessionStatus.protoMergeImpl(plus: pbandk.Message?): SessionStatus = (plus as? SessionStatus)?.copy(
+    statusCode = plus.statusCode ?: statusCode,
+    errorText = plus.errorText ?: errorText,
+    resultCode = plus.resultCode ?: resultCode,
+    results = results?.plus(plus.results) ?: plus.results,
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun SessionStatus.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SessionStatus {
+    var statusCode: SessionStatusCode? = null
+    var errorText: String? = null
+    var resultCode: Int? = null
+    var results: ResultsBundle? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> statusCode = _fieldValue as SessionStatusCode
+            2 -> errorText = _fieldValue as String
+            3 -> resultCode = _fieldValue as Int
+            4 -> results = _fieldValue as ResultsBundle
+        }
+    }
+    return SessionStatus(statusCode, errorText, resultCode, results, unknownFields)
+}
+
+fun Session?.orDefault() = this ?: Session.defaultInstance
+
+private fun Session.protoMergeImpl(plus: pbandk.Message?): Session = (plus as? Session)?.copy(
+    testStatus = testStatus + plus.testStatus,
+    sessionStatus = sessionStatus?.plus(plus.sessionStatus) ?: plus.sessionStatus,
+    unknownFields = unknownFields + plus.unknownFields
+) ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun Session.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Session {
+    var testStatus: pbandk.ListWithSize.Builder<TestStatus>? = null
+    var sessionStatus: SessionStatus? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> testStatus = (testStatus ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as Sequence<TestStatus> }
+            2 -> sessionStatus = _fieldValue as SessionStatus
+        }
+    }
+    return Session(pbandk.ListWithSize.Builder.fixed(testStatus), sessionStatus, unknownFields)
+}

--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/transform/ProtoInstrumentationResponseTransformer.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/transform/ProtoInstrumentationResponseTransformer.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright (C) 2021 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.request.transform
+
+import com.malinskiy.adam.Const
+import com.malinskiy.adam.extension.*
+import com.malinskiy.adam.request.testrunner.*
+import com.malinskiy.adam.request.testrunner.model.*
+import com.malinskiy.adam.request.testrunner.proto.ResultsBundleEntry
+import com.malinskiy.adam.request.testrunner.proto.Session
+import com.malinskiy.adam.request.testrunner.proto.SessionStatusCode
+import pbandk.InvalidProtocolBufferException
+import pbandk.decodeFromByteBuffer
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
+
+/**
+ * WARNING: the logcat field in the proto message can lead to huge memory consumption on devices as well as on the user's side.
+ *
+ * The logcat is read only once on the am instrument's side and the StringBuilder is uncapped. So if you have a huge logcat -
+ * you'll have to transfer it via the socket and then also parse from protobuf and allocate a String in the JVM.
+ *
+ * The read loop catches exception and doesn't have a way to suspend until it can read the message properly.
+ *
+ * This needs work on the am instrument's side:
+ * - proper framing support with length of the message sent first, then the actual message
+ * - streaming logcat support: this should NOT be a one-shot operation, instead we can append to file while the test executes
+ * - logcat command customisation: there is no way to change the format or filter at the moment, the command is hard-coded
+ *
+ * see frameworks/base/cmds/am/src/com/android/commands/am/Instrument.java#readLogcat
+ */
+class ProtoInstrumentationResponseTransformer(maxProtobufPacketLength: Long = Const.MAX_PROTOBUF_PACKET_LENGTH) :
+    ProgressiveResponseTransformer<List<TestEvent>?> {
+    private val backingFile = RandomAccessFile(File.createTempFile("tmp-proto", null, null), "rw")
+    private val channel = backingFile.channel
+    private val buffer: MappedByteBuffer =
+        channel.map(FileChannel.MapMode.READ_WRITE, 0L, maxProtobufPacketLength).apply { compatLimit(0) }
+
+    private var state: State = NotStarted
+    private var testStatuses = linkedMapOf<TestIdentifier, TestStatusAggregator>()
+
+    private val timeRegex = "Time: \\s*([\\d\\,]*[\\d\\.]+)".toRegex()
+
+    override suspend fun process(bytes: ByteArray, offset: Int, limit: Int): List<TestEvent>? {
+        if (state.terminal) return null
+
+        buffer.compatLimit(buffer.limit() + limit)
+        buffer.put(bytes, offset, limit)
+
+        try {
+            buffer.compatPosition(0)
+            val session = Session.decodeFromByteBuffer(buffer)
+            val events = mutableListOf<TestEvent>()
+            for (status in session.testStatus) {
+                if (state == NotStarted) {
+                    val testCount = status.results?.entries?.filter { entry -> entry.key?.let { it == StatusKey.NUMTESTS.value } ?: false }
+                        ?.mapNotNull { it.valueInt }
+                        ?.firstOrNull()
+                        ?: 0
+
+                    if (testCount == 0) return null
+
+                    state = Running
+                    events.add(TestRunStartedEvent(testCount))
+                }
+
+                var testClassName = ""
+                var testMethodName = ""
+                var stackTrace = ""
+                val testMetrics = mutableMapOf<String, String>()
+                status.results?.entries?.forEach { entry ->
+                    if (entry.key != null) {
+                        when (StatusKey.of(entry.key)) {
+                            StatusKey.TEST -> testMethodName = entry.valueString ?: testClassName
+                            StatusKey.CLASS -> testClassName = entry.valueString ?: testMethodName
+                            StatusKey.STACK -> stackTrace = entry.valueString ?: stackTrace
+                            StatusKey.CURRENT -> Unit //Test index
+                            StatusKey.NUMTESTS, StatusKey.ERROR, StatusKey.SHORTMSG, StatusKey.STREAM, StatusKey.ID -> Unit
+                            StatusKey.UNKNOWN -> testMetrics[entry.key] = entry.valueToString()
+                        }
+                    }
+                }
+
+                var resultCodeOverride: Status? = null
+                if (testClassName.isEmpty() && testMethodName.isEmpty()) {
+                    testStatuses.entries.lastOrNull()?.let { previousTestStatus ->
+                        testClassName = previousTestStatus.key.className
+                        testMethodName = previousTestStatus.key.testName
+                        resultCodeOverride = previousTestStatus.value.statusCode
+                    } ?: run { testClassName = ""; testMethodName = "" }
+                }
+
+                if (testClassName.isNotBlank() && testMethodName.isNotBlank()) {
+                    events.addAll(
+                        updateTestState(
+                            testClassName,
+                            testMethodName,
+                            resultCodeOverride ?: Status.valueOf(status.resultCode),
+                            status.logcat,
+                            stackTrace,
+                            testMetrics
+                        )
+                    )
+                }
+            }
+
+            if (session.sessionStatus != null) {
+                state = Finished
+
+                val testRunMetrics = mutableMapOf<String, String>()
+                when (session.sessionStatus.statusCode) {
+                    SessionStatusCode.SESSION_FINISHED, null -> {
+                        if ((session.sessionStatus.resultCode ?: SessionResultCode.ERROR.value) == SessionResultCode.ERROR.value) {
+                            val errorMessage = session.sessionStatus.results?.entries
+                                ?.filter { entry ->
+                                    entry.key?.let { it == StatusKey.SHORTMSG.value } ?: false
+                                }
+                                ?.mapNotNull { it.valueString }?.firstOrNull() ?: ""
+                            events.add(TestRunFailed(errorMessage))
+                        }
+
+                        session.sessionStatus.results?.entries?.forEach { entry ->
+                            if (entry.key != null && StatusKey.of(entry.key) == StatusKey.UNKNOWN) {
+                                testRunMetrics[entry.key] = entry.valueToString()
+                            }
+                        }
+                    }
+                    SessionStatusCode.SESSION_ABORTED -> {
+                        val errorText = session.sessionStatus.errorText ?: ""
+                        val lastTest = testStatuses.entries.lastOrNull()
+
+                        if (lastTest != null && !lastTest.value.statusCode.isTerminal()) {
+                            events.add(TestFailed(lastTest.key, ""))
+
+                            lastTest.value.metrics[Const.TEST_LOGCAT_METRIC] = lastTest.value.logcatBuilder.toString()
+                            events.add(TestEnded(lastTest.key, lastTest.value.metrics))
+                        }
+
+                        events.add(TestRunFailed(errorText))
+                    }
+                    is SessionStatusCode.UNRECOGNIZED -> Unit
+                }
+
+                val sessionOutput = session.sessionStatus.results?.entries
+                    ?.filter { it.key == StatusKey.STREAM.value }
+                    ?.mapNotNull { it.valueToString() }
+                    ?.firstOrNull()
+
+                if (sessionOutput != null) {
+                    val matchResult = timeRegex.find(sessionOutput)
+                    val elapsedTime = matchResult?.groups?.get(1)?.let { it.value.toFloatOrNull() }?.let { (it * 1000).toLong() } ?: 0L
+                    events.add(TestRunEnded(elapsedTime, testRunMetrics))
+                }
+            }
+
+            /**
+             * Handling fragmentation
+             * This will fail if the protobuf message contains the field multiple times and protoSize is not equal to actual read size
+             */
+            val readSize = session.protoSize
+            val currentLimit = buffer.limit()
+            buffer.compatPosition(readSize)
+            buffer.compact()
+            buffer.compatLimit(currentLimit - readSize)
+
+            return events
+        } catch (e: InvalidProtocolBufferException) {
+            //wait for more input
+            buffer.compatPosition(buffer.limit())
+            return null
+        }
+    }
+
+    override fun transform(): List<TestEvent>? {
+        channel.close()
+        backingFile.close()
+        return null
+    }
+
+    private fun updateTestState(
+        className: String,
+        methodName: String,
+        resultCode: Status,
+        logcat: String?,
+        stackTrace: String,
+        testMetrics: Map<String, String>
+    ): List<TestEvent> {
+        val id = TestIdentifier(className, methodName)
+        var events = mutableListOf<TestEvent>()
+        val statusAggregator = testStatuses.computeIfAbsent(id) {
+            events.add(TestStarted(id))
+            return@computeIfAbsent TestStatusAggregator(Status.START)
+        }
+
+        logcat?.let { statusAggregator.logcatBuilder.append(it) }
+        statusAggregator.metrics.putAll(testMetrics)
+
+        if (statusAggregator.statusCode == resultCode) {
+            return events
+        }
+
+        when (resultCode) {
+            Status.ERROR, Status.FAILURE -> {
+                events.add(TestFailed(id, stackTrace))
+            }
+            Status.IGNORED -> {
+                events.add(TestIgnored(id))
+                statusAggregator.logcatBuilder.clear()
+            }
+            Status.ASSUMPTION_FAILURE -> {
+                events.add(TestAssumptionFailed(id, stackTrace))
+            }
+            Status.SUCCESS, Status.START, Status.IN_PROGRESS, Status.UNKNOWN -> Unit
+        }
+
+        if (resultCode.isTerminal()) {
+            statusAggregator.metrics[Const.TEST_LOGCAT_METRIC] = statusAggregator.logcatBuilder.toString()
+            events.add(TestEnded(id, statusAggregator.metrics))
+        }
+
+        return events
+    }
+}
+
+private fun ResultsBundleEntry.valueToString(): String {
+    return valueString ?: valueInt?.toString() ?: valueLong?.toString() ?: valueFloat?.toString() ?: valueDouble?.toString()
+    ?: valueBytes?.toString() ?: valueBundle?.toString() ?: ""
+}

--- a/src/main/kotlin/com/malinskiy/adam/request/transform/ProgressiveResponseTransformer.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/transform/ProgressiveResponseTransformer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Anton Malinskiy
+ * Copyright (C) 2021 Anton Malinskiy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.malinskiy.adam.request.testrunner
+package com.malinskiy.adam.request.transform
 
-data class TestIdentifier(
-    val className: String,
-    val testName: String
-)
+interface ProgressiveResponseTransformer<T : Any?> {
+    suspend fun process(bytes: ByteArray, offset: Int, limit: Int): T
+    fun transform(): T
+}

--- a/src/main/kotlin/com/malinskiy/adam/transport/BufferFactory.kt
+++ b/src/main/kotlin/com/malinskiy/adam/transport/BufferFactory.kt
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer
 
 internal const val DEFAULT_BUFFER_SIZE = 4096
 
-val AdamFilePool: ObjectPool<ByteBuffer> = ByteBufferPool(Const.MAX_FILE_PACKET_LENGTH, DEFAULT_BUFFER_SIZE)
+val AdamFilePool: ObjectPool<ByteBuffer> = ByteBufferPool(DEFAULT_BUFFER_SIZE, Const.MAX_FILE_PACKET_LENGTH)
 val AdamDefaultPool: ObjectPool<ByteBuffer> = ByteBufferPool(Const.DEFAULT_BUFFER_SIZE, DEFAULT_BUFFER_SIZE)
 
 inline fun <R> withDefaultBuffer(block: ByteBuffer.() -> R): R {

--- a/src/main/proto/instrumentation-data.proto
+++ b/src/main/proto/instrumentation-data.proto
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2021 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This proto definition is copied from frameworks/base/cmds/am/proto/instrumentation_data.proto.
+
+syntax = "proto2";
+package android.am;
+
+option java_package = "com.android.commands.am";
+
+message ResultsBundleEntry {
+  optional string key = 1;
+
+  optional string value_string = 2;
+  optional sint32 value_int = 3;
+  optional float value_float = 4;
+  optional double value_double = 5;
+  optional sint64 value_long = 6;
+  optional ResultsBundle value_bundle = 7;
+  optional bytes value_bytes = 8;
+}
+
+message ResultsBundle {
+  repeated ResultsBundleEntry entries = 1;
+}
+
+message TestStatus {
+  optional sint32 result_code = 3;
+  optional ResultsBundle results = 4;
+  optional string logcat = 5;
+}
+
+enum SessionStatusCode {
+  /**
+   * The command ran successfully. This does not imply that the tests passed.
+   */
+  SESSION_FINISHED = 0;
+
+  /**
+   * There was an unrecoverable error running the tests.
+   */
+  SESSION_ABORTED = 1;
+}
+
+message SessionStatus {
+  optional SessionStatusCode status_code = 1;
+  optional string error_text = 2;
+  optional sint32 result_code = 3;
+  optional ResultsBundle results = 4;
+}
+
+message Session {
+  repeated TestStatus test_status = 1;
+  optional SessionStatus session_status = 2;
+}

--- a/src/main/proto/instrumentation-data.proto
+++ b/src/main/proto/instrumentation-data.proto
@@ -19,7 +19,7 @@
 syntax = "proto2";
 package android.am;
 
-option java_package = "com.android.commands.am";
+option java_package = "com.malinskiy.adam.request.testrunner.proto";
 
 message ResultsBundleEntry {
   optional string key = 1;

--- a/src/test/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequestTest.kt
+++ b/src/test/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequestTest.kt
@@ -17,14 +17,12 @@
 package com.malinskiy.adam.request.testrunner
 
 import assertk.assertThat
+import assertk.assertions.containsOnly
 import assertk.assertions.isEqualTo
 import com.malinskiy.adam.Const
 import com.malinskiy.adam.extension.toAndroidChannel
 import com.malinskiy.adam.server.AndroidDebugBridgeServer
-import io.ktor.utils.io.ByteChannel
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.ByteWriteChannel
-import io.ktor.utils.io.close
+import io.ktor.utils.io.*
 import kotlinx.coroutines.channels.receiveOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -89,13 +87,13 @@ class TestRunnerRequestTest {
                     serial = "serial",
                     scope = this
                 )
-                val builder = StringBuilder()
+                val events = mutableListOf<TestEvent>()
                 while (!channel.isClosedForReceive) {
                     val chunk = channel.receiveOrNull() ?: break
-                    builder.append(chunk)
+                    events.addAll(chunk)
                 }
 
-                assertThat(builder.toString()).isEqualTo("something-something")
+                assertThat(events).containsOnly(TestRunFailed("No test results"))
 
                 server.dispose()
             }.join()

--- a/src/test/kotlin/com/malinskiy/adam/request/testrunner/transform/InstrumentationResponseTransformerTest.kt
+++ b/src/test/kotlin/com/malinskiy/adam/request/testrunner/transform/InstrumentationResponseTransformerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Anton Malinskiy
+ * Copyright (C) 2021 Anton Malinskiy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.malinskiy.adam.request.transform
+package com.malinskiy.adam.request.testrunner.transform
 
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -22,6 +22,7 @@ import assertk.assertions.isEqualTo
 import com.malinskiy.adam.Const
 import com.malinskiy.adam.request.testrunner.TestEvent
 import com.malinskiy.adam.request.testrunner.TestRunFailed
+import com.malinskiy.adam.request.transform.InstrumentationResponseTransformer
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
@@ -37,12 +38,11 @@ class InstrumentationResponseTransformerTest {
             val events = mutableListOf<TestEvent>()
             for (line in lines) {
                 val bytes = (line + '\n').toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                transformer.process(bytes, 0, bytes.size)
-                transformer.transform()?.let {
+                transformer.process(bytes, 0, bytes.size)?.let {
                     events.addAll(it)
                 }
             }
-            transformer.close()?.let { events.addAll(it) }
+            transformer.transform()?.let { events.addAll(it) }
 
             assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
                 .isEqualTo(javaClass.getResourceAsStream("/instrumentation/log_3.expected").reader().readText())
@@ -59,12 +59,11 @@ class InstrumentationResponseTransformerTest {
             val events = mutableListOf<TestEvent>()
             for (line in lines) {
                 val bytes = (line + '\n').toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                transformer.process(bytes, 0, bytes.size)
-                transformer.transform()?.let {
+                transformer.process(bytes, 0, bytes.size)?.let {
                     events.addAll(it)
                 }
             }
-            transformer.close()?.let { events.addAll(it) }
+            transformer.transform()?.let { events.addAll(it) }
 
             assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
                 .isEqualTo(javaClass.getResourceAsStream("/instrumentation/log_2.expected").reader().readText())
@@ -81,12 +80,11 @@ class InstrumentationResponseTransformerTest {
             val events = mutableListOf<TestEvent>()
             for (line in lines) {
                 val bytes = (line + '\n').toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                transformer.process(bytes, 0, bytes.size)
-                transformer.transform()?.let {
+                transformer.process(bytes, 0, bytes.size)?.let {
                     events.addAll(it)
                 }
             }
-            transformer.close()?.let { events.addAll(it) }
+            transformer.transform()?.let { events.addAll(it) }
 
             assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
                 .isEqualTo(javaClass.getResourceAsStream("/instrumentation/log_1.expected").reader().readText())
@@ -97,7 +95,7 @@ class InstrumentationResponseTransformerTest {
     fun testNoResultsReported() {
         runBlocking {
             val transformer = InstrumentationResponseTransformer()
-            val list = transformer.close()
+            val list = transformer.transform()
             assertThat(list!!).containsExactly(TestRunFailed("No test results"))
         }
     }
@@ -112,12 +110,11 @@ class InstrumentationResponseTransformerTest {
             val events = mutableListOf<TestEvent>()
             for (line in lines) {
                 val bytes = (line + '\n').toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                transformer.process(bytes, 0, bytes.size)
-                transformer.transform()?.let {
+                transformer.process(bytes, 0, bytes.size)?.let {
                     events.addAll(it)
                 }
             }
-            transformer.close()?.let { events.addAll(it) }
+            transformer.transform()?.let { events.addAll(it) }
 
             assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
                 .isEqualTo(javaClass.getResourceAsStream("/instrumentation/log_4.expected").reader().readText())
@@ -134,12 +131,11 @@ class InstrumentationResponseTransformerTest {
             val events = mutableListOf<TestEvent>()
             for (line in lines) {
                 val bytes = (line + '\n').toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                transformer.process(bytes, 0, bytes.size)
-                transformer.transform()?.let {
+                transformer.process(bytes, 0, bytes.size)?.let {
                     events.addAll(it)
                 }
             }
-            transformer.close()?.let { events.addAll(it) }
+            transformer.transform()?.let { events.addAll(it) }
 
             assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
                 .isEqualTo(javaClass.getResourceAsStream("/instrumentation/log_5.expected").reader().readText())
@@ -158,12 +154,11 @@ class InstrumentationResponseTransformerTest {
         val events = mutableListOf<TestEvent>()
         for (line in lines) {
             val bytes = (line + '\n').toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-            transformer.process(bytes, 0, bytes.size)
-            transformer.transform()?.let {
+            transformer.process(bytes, 0, bytes.size)?.let {
                 events.addAll(it)
             }
         }
-        transformer.close()?.let { events.addAll(it) }
+        transformer.transform()?.let { events.addAll(it) }
 
         assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
             .isEqualTo(javaClass.getResourceAsStream("/instrumentation/log_6.expected").reader().readText())

--- a/src/test/kotlin/com/malinskiy/adam/request/testrunner/transform/ProtoInstrumentationResponseTransformerTest.kt
+++ b/src/test/kotlin/com/malinskiy/adam/request/testrunner/transform/ProtoInstrumentationResponseTransformerTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.request.testrunner.transform
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.malinskiy.adam.request.testrunner.TestEvent
+import com.malinskiy.adam.request.transform.ProtoInstrumentationResponseTransformer
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class ProtoInstrumentationResponseTransformerTest {
+    @Test
+    fun testSingleFailure() {
+        runBlocking {
+            val transformer = ProtoInstrumentationResponseTransformer()
+
+            val protoBytes = javaClass.getResourceAsStream("/instrumentation/proto_1.input").readBytes()
+
+            val events = mutableListOf<TestEvent>()
+
+            transformer.process(protoBytes, 0, 175)?.let { events.addAll(it) }
+            transformer.process(protoBytes, 175, 11776)?.let { events.addAll(it) }
+            transformer.process(protoBytes, 175 + 11776, 8347)?.let { events.addAll(it) }
+            transformer.process(protoBytes, 175 + 11776 + 8347, 2466)?.let { events.addAll(it) }
+            transformer.transform()?.let { events.addAll(it) }
+
+            assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
+                .isEqualTo(javaClass.getResourceAsStream("/instrumentation/proto_log_1.expected").reader().readText())
+        }
+    }
+}

--- a/src/test/resources/instrumentation/proto_1.input
+++ b/src/test/resources/instrumentation/proto_1.input
@@ -1,0 +1,268 @@
+
+¨"ß
+(
+classcom.example.AbstractFailingTest
+
+current
+
+idAndroidJUnitRunner
+
+numtests
++
+stream!
+com.example.AbstractFailingTest:
+
+testtestAlwaysFailing
+óù"Á%
+(
+classcom.example.AbstractFailingTest
+
+current
+
+idAndroidJUnitRunner
+
+numtests
+î
+stackäjava.lang.AssertionError
+	at org.junit.Assert.fail(Assert.java:86)
+	at org.junit.Assert.assertTrue(Assert.java:41)
+	at org.junit.Assert.assertTrue(Assert.java:52)
+	at com.example.AbstractFailingTest.testAlwaysFailing(AbstractFailingTest.kt:22)
+	at java.lang.reflect.Method.invoke(Native Method)
+	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+	at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
+	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runners.Suite.runChild(Suite.java:128)
+	at org.junit.runners.Suite.runChild(Suite.java:27)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
+	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
+	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
+
+”
+stream»
+Error in testAlwaysFailing(com.example.AbstractFailingTest):
+java.lang.AssertionError
+	at org.junit.Assert.fail(Assert.java:86)
+	at org.junit.Assert.assertTrue(Assert.java:41)
+	at org.junit.Assert.assertTrue(Assert.java:52)
+	at com.example.AbstractFailingTest.testAlwaysFailing(AbstractFailingTest.kt:22)
+	at java.lang.reflect.Method.invoke(Native Method)
+	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+	at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
+	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runners.Suite.runChild(Suite.java:128)
+	at org.junit.runners.Suite.runChild(Suite.java:27)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
+	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
+	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
+
+
+testtestAlwaysFailing*®w--------- beginning of main
+01-09 23:49:55.061 10254 17117 17117 I MonitoringInstr: Activities that are still in CREATED to STOPPED: 0
+01-09 23:49:55.062 10254 17117 17139 W ActivityTestRule: getActivityIntent() returned null using default: Intent(Intent.ACTION_MAIN)
+01-09 23:49:55.063 10254 17117 17139 I ActivityTestRule: Launching activity: ComponentInfo{com.example/com.example.MainActivity}
+01-09 23:49:55.068 10254 17117 17141 D MonitoringInstr: execStartActivity(context, ibinder, ibinder, activity, intent, int, bundle
+--------- beginning of system
+01-09 23:49:55.069  1000  2027  4636 I ActivityTaskManager: START u0 {act=android.intent.action.MAIN flg=0x14000000 cmp=com.example/.MainActivity} from uid 10254
+01-09 23:49:55.084  1000  2027  2049 E system_server: Invalid ID 0x00000000.
+01-09 23:49:55.085  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.088  1000  2027  2815 I chatty  : uid=1000(system) Binder:2027_F identical 28 lines
+01-09 23:49:55.088  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.088 10254 17117 17117 W ActivityThread: handleWindowVisibility: no activity for token android.os.BinderProxy@6ce4f93
+01-09 23:49:55.091   gps  1795  2251 E GnssHAL_GnssInterface: gnssSvStatusCb: a: input svInfo.flags is 8
+01-09 23:49:55.091   gps  1795  2251 E GnssHAL_GnssInterface: gnssSvStatusCb: b: input svInfo.flags is 8
+01-09 23:49:55.091  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.091  1000  2027  2815 I chatty  : uid=1000(system) Binder:2027_F identical 8 lines
+01-09 23:49:55.091  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.101 10254 17117 17117 W RenderThread: type=1400 audit(0.0:1415): avc: denied { write } for name="property_service" dev="tmpfs" ino=758 scontext=u:r:untrusted_app_27:s0:c512,c768 tcontext=u:object_r:property_socket:s0 tclass=sock_file permissive=0
+01-09 23:49:55.104  1000  1816  2561 E SurfaceFlinger: ro.sf.lcd_density must be defined as a build property
+01-09 23:49:55.104  1000  1816  2561 E SurfaceFlinger: ro.sf.lcd_density must be defined as a build property
+01-09 23:49:55.111 10254 17117 17144 D libEGL  : Emulator has host GPU support, qemu.gles is set to 1.
+01-09 23:49:55.112 10254 17117 17144 W libc    : Unable to set property "qemu.gles" to "1": connection failed; errno=13 (Permission denied)
+01-09 23:49:55.125 10254 17117 17144 D libEGL  : loaded /vendor/lib/egl/libEGL_emulation.so
+01-09 23:49:55.126 10254 17117 17144 D libEGL  : loaded /vendor/lib/egl/libGLESv1_CM_emulation.so
+01-09 23:49:55.126 10254 17117 17144 D libEGL  : loaded /vendor/lib/egl/libGLESv2_emulation.so
+01-09 23:49:55.131  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.131 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: PRE_ON_CREATE
+01-09 23:49:55.154  1000  2027  2049 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.154  1000  2027  2049 I chatty  : uid=1000(system) android.anim identical 8 lines
+01-09 23:49:55.154  1000  2027  2049 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.200 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: CREATED
+01-09 23:49:55.201 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: STARTED
+01-09 23:49:55.204 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: RESUMED
+01-09 23:49:55.217 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.224 10098  2727 14416 I Icing   : Indexing com.google.android.gms-apps from com.google.android.gms
+01-09 23:49:55.225 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.226 10098  2727 14416 I Icing   : Indexing com.google.android.gms-apps from com.google.android.gms
+01-09 23:49:55.226 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.234 10098  2727 14416 I Icing   : Indexing com.google.android.gms-apps from com.google.android.gms
+01-09 23:49:55.234 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.247 10254 17117 17142 D HostConnection: HostConnection::get() New Host Connection established 0xd633f190, tid 17142
+01-09 23:49:55.248 10254 17117 17142 D HostConnection: HostComposition ext ANDROID_EMU_CHECKSUM_HELPER_v1 ANDROID_EMU_native_sync_v2 ANDROID_EMU_native_sync_v3 ANDROID_EMU_native_sync_v4 ANDROID_EMU_dma_v1 ANDROID_EMU_direct_mem ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_YUV420_888_to_NV21 ANDROID_EMU_YUV_Cache ANDROID_EMU_async_unmap_buffer GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr ANDROID_EMU_host_side_tracing ANDROID_EMU_async_frame_commands ANDROID_EMU_gles_max_version_3_0 
+01-09 23:49:55.252 10254 17117 17142 W OpenGLRenderer: Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
+01-09 23:49:55.253 10254 17117 17142 D eglCodecCommon: setVertexArrayObject: set vao to 0 (0) 0 0
+01-09 23:49:55.253 10254 17117 17142 D EGL_emulation: eglCreateContext: 0xd631a2a0: maj 3 min 0 rcv 3
+01-09 23:49:55.264  root  1929  1929 E netmgr  : Failed to open QEMU pipe 'qemud:network': Invalid argument
+01-09 23:49:55.270 10254 17117 17142 D EGL_emulation: eglMakeCurrent: 0xd631a2a0: ver 3 0 (tinfo 0xd630f7e0)
+01-09 23:49:55.276  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.279  1000  1681  1681 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+01-09 23:49:55.279 10254 17117 17142 W Gralloc3: mapper 3.x is not supported
+01-09 23:49:55.280 10254 17117 17142 D HostConnection: createUnique: call
+01-09 23:49:55.280 10254 17117 17142 D HostConnection: HostConnection::get() New Host Connection established 0xd633f2d0, tid 17142
+01-09 23:49:55.281 10254 17117 17142 D HostConnection: HostComposition ext ANDROID_EMU_CHECKSUM_HELPER_v1 ANDROID_EMU_native_sync_v2 ANDROID_EMU_native_sync_v3 ANDROID_EMU_native_sync_v4 ANDROID_EMU_dma_v1 ANDROID_EMU_direct_mem ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_YUV420_888_to_NV21 ANDROID_EMU_YUV_Cache ANDROID_EMU_async_unmap_buffer GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr ANDROID_EMU_host_side_tracing ANDROID_EMU_async_frame_commands ANDROID_EMU_gles_max_version_3_0 
+01-09 23:49:55.281 10254 17117 17142 D eglCodecCommon: allocate: Ask for block of size 0x1000
+01-09 23:49:55.281 10254 17117 17142 D eglCodecCommon: allocate: ioctl allocate returned offset 0x3ff7ff000 size 0x2000
+01-09 23:49:55.282  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.285  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.286 10254 17117 17142 D EGL_emulation: eglMakeCurrent: 0xd631a2a0: ver 3 0 (tinfo 0xd630f7e0)
+01-09 23:49:55.288 10254 17117 17142 D eglCodecCommon: setVertexArrayObject: set vao to 0 (0) 0 0
+01-09 23:49:55.371  1000  2027  2053 I ActivityTaskManager: Displayed com.example/.MainActivity: +296ms
+01-09 23:49:55.379 10254 17117 17117 I AssistStructure: Flattened final assist data: 736 bytes, containing 1 windows, 3 views
+01-09 23:49:55.388 10098  2534  2534 W lil     : Pending fill request while another request in the same session was triggered. [CONTEXT service_id=177 ]
+01-09 23:49:55.428  1000  2027  2817 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.429  1000  2027  2817 I chatty  : uid=1000(system) Binder:2027_10 identical 8 lines
+01-09 23:49:55.429  1000  2027  2817 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.431 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: PAUSED
+01-09 23:49:55.433  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.437  1000  2027  2815 I chatty  : uid=1000(system) Binder:2027_F identical 28 lines
+01-09 23:49:55.437  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.441 10090  2421  2849 D EGL_emulation: eglMakeCurrent: 0xe957fee0: ver 3 0 (tinfo 0xde4c6490)
+01-09 23:49:55.441 10110  2974  3167 D EGL_emulation: eglMakeCurrent: 0xd631b0e0: ver 3 0 (tinfo 0xd630f900)
+01-09 23:49:55.444  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 5312512
+01-09 23:49:55.452 10254 17117 17142 D EGL_emulation: eglMakeCurrent: 0xd631a2a0: ver 3 0 (tinfo 0xd630f7e0)
+01-09 23:49:55.454 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: STOPPED
+01-09 23:49:55.459 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: DESTROYED
+01-09 23:49:55.466 10254 17117 17139 I TestRunner: failed: testAlwaysFailing(com.example.AbstractFailingTest)
+01-09 23:49:55.466 10254 17117 17139 I TestRunner: ----- begin exception -----
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: java.lang.AssertionError
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.Assert.fail(Assert.java:86)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.Assert.assertTrue(Assert.java:41)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.Assert.assertTrue(Assert.java:52)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at com.example.AbstractFailingTest.testAlwaysFailing(AbstractFailingTest.kt:22)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at java.lang.reflect.Method.invoke(Native Method)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.Suite.runChild(Suite.java:128)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.Suite.runChild(Suite.java:27)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: ----- end exception -----
+01-09 23:49:55.471 10254 17117 17139 I TestRunner: finished: testAlwaysFailing(com.example.AbstractFailingTest)
+01-09 23:49:55.480  1000  2027  2812 D WindowManager: relayoutVisibleWindow: Window{ee55c84 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity EXITING} mAnimatingExit=true, mRemoveOnExit=false, mDestroying=false
+01-09 23:49:55.480  1000  2027  2815 D WindowManager: relayoutVisibleWindow: Window{3344f1b u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity EXITING} mAnimatingExit=true, mRemoveOnExit=false, mDestroying=false
+01-09 23:49:55.484  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.489  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.493  1000  1797  1797 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.497  1000  1797  1797 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.500 10090  2421  2849 D EGL_emulation: eglMakeCurrent: 0xe957fee0: ver 3 0 (tinfo 0xde4c6490)
+01-09 23:49:55.501  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.509  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.515  1000  2027  4636 I ActivityTaskManager: Activity reported stop, but no longer stopping: ActivityRecord{5645067 u0 com.google.android.apps.nexuslauncher/.NexusLauncherActivity t4}
+01-09 23:49:55.515 10110  2974  3167 D EGL_emulation: eglMakeCurrent: 0xd631b0e0: ver 3 0 (tinfo 0xd630f900)
+ü"ö
+ó
+streamå
+
+Time: 0.526
+There was 1 failure:
+1) testAlwaysFailing(com.example.AbstractFailingTest)
+java.lang.AssertionError
+	at org.junit.Assert.fail(Assert.java:86)
+	at org.junit.Assert.assertTrue(Assert.java:41)
+	at org.junit.Assert.assertTrue(Assert.java:52)
+	at com.example.AbstractFailingTest.testAlwaysFailing(AbstractFailingTest.kt:22)
+	at java.lang.reflect.Method.invoke(Native Method)
+	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+	at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
+	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runners.Suite.runChild(Suite.java:128)
+	at org.junit.runners.Suite.runChild(Suite.java:27)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
+	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
+	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
+
+FAILURES!!!
+Tests run: 1,  Failures: 1
+

--- a/src/test/resources/instrumentation/proto_log_1.expected
+++ b/src/test/resources/instrumentation/proto_log_1.expected
@@ -1,0 +1,163 @@
+TestRunStartedEvent(testCount=1)
+TestStarted(id=TestIdentifier(className=com.example.AbstractFailingTest, testName=testAlwaysFailing))
+TestFailed(id=TestIdentifier(className=com.example.AbstractFailingTest, testName=testAlwaysFailing), stackTrace=java.lang.AssertionError
+	at org.junit.Assert.fail(Assert.java:86)
+	at org.junit.Assert.assertTrue(Assert.java:41)
+	at org.junit.Assert.assertTrue(Assert.java:52)
+	at com.example.AbstractFailingTest.testAlwaysFailing(AbstractFailingTest.kt:22)
+	at java.lang.reflect.Method.invoke(Native Method)
+	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+	at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
+	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runners.Suite.runChild(Suite.java:128)
+	at org.junit.runners.Suite.runChild(Suite.java:27)
+	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
+	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
+	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
+)
+TestEnded(id=TestIdentifier(className=com.example.AbstractFailingTest, testName=testAlwaysFailing), metrics={com.malinskiy.adam.logcat=--------- beginning of main
+01-09 23:49:55.061 10254 17117 17117 I MonitoringInstr: Activities that are still in CREATED to STOPPED: 0
+01-09 23:49:55.062 10254 17117 17139 W ActivityTestRule: getActivityIntent() returned null using default: Intent(Intent.ACTION_MAIN)
+01-09 23:49:55.063 10254 17117 17139 I ActivityTestRule: Launching activity: ComponentInfo{com.example/com.example.MainActivity}
+01-09 23:49:55.068 10254 17117 17141 D MonitoringInstr: execStartActivity(context, ibinder, ibinder, activity, intent, int, bundle
+--------- beginning of system
+01-09 23:49:55.069  1000  2027  4636 I ActivityTaskManager: START u0 {act=android.intent.action.MAIN flg=0x14000000 cmp=com.example/.MainActivity} from uid 10254
+01-09 23:49:55.084  1000  2027  2049 E system_server: Invalid ID 0x00000000.
+01-09 23:49:55.085  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.088  1000  2027  2815 I chatty  : uid=1000(system) Binder:2027_F identical 28 lines
+01-09 23:49:55.088  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.088 10254 17117 17117 W ActivityThread: handleWindowVisibility: no activity for token android.os.BinderProxy@6ce4f93
+01-09 23:49:55.091   gps  1795  2251 E GnssHAL_GnssInterface: gnssSvStatusCb: a: input svInfo.flags is 8
+01-09 23:49:55.091   gps  1795  2251 E GnssHAL_GnssInterface: gnssSvStatusCb: b: input svInfo.flags is 8
+01-09 23:49:55.091  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.091  1000  2027  2815 I chatty  : uid=1000(system) Binder:2027_F identical 8 lines
+01-09 23:49:55.091  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.101 10254 17117 17117 W RenderThread: type=1400 audit(0.0:1415): avc: denied { write } for name="property_service" dev="tmpfs" ino=758 scontext=u:r:untrusted_app_27:s0:c512,c768 tcontext=u:object_r:property_socket:s0 tclass=sock_file permissive=0
+01-09 23:49:55.104  1000  1816  2561 E SurfaceFlinger: ro.sf.lcd_density must be defined as a build property
+01-09 23:49:55.104  1000  1816  2561 E SurfaceFlinger: ro.sf.lcd_density must be defined as a build property
+01-09 23:49:55.111 10254 17117 17144 D libEGL  : Emulator has host GPU support, qemu.gles is set to 1.
+01-09 23:49:55.112 10254 17117 17144 W libc    : Unable to set property "qemu.gles" to "1": connection failed; errno=13 (Permission denied)
+01-09 23:49:55.125 10254 17117 17144 D libEGL  : loaded /vendor/lib/egl/libEGL_emulation.so
+01-09 23:49:55.126 10254 17117 17144 D libEGL  : loaded /vendor/lib/egl/libGLESv1_CM_emulation.so
+01-09 23:49:55.126 10254 17117 17144 D libEGL  : loaded /vendor/lib/egl/libGLESv2_emulation.so
+01-09 23:49:55.131  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.131 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: PRE_ON_CREATE
+01-09 23:49:55.154  1000  2027  2049 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.154  1000  2027  2049 I chatty  : uid=1000(system) android.anim identical 8 lines
+01-09 23:49:55.154  1000  2027  2049 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.200 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: CREATED
+01-09 23:49:55.201 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: STARTED
+01-09 23:49:55.204 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: RESUMED
+01-09 23:49:55.217 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.224 10098  2727 14416 I Icing   : Indexing com.google.android.gms-apps from com.google.android.gms
+01-09 23:49:55.225 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.226 10098  2727 14416 I Icing   : Indexing com.google.android.gms-apps from com.google.android.gms
+01-09 23:49:55.226 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.234 10098  2727 14416 I Icing   : Indexing com.google.android.gms-apps from com.google.android.gms
+01-09 23:49:55.234 10098  2727 14416 I Icing   : Indexing done com.google.android.gms-apps
+01-09 23:49:55.247 10254 17117 17142 D HostConnection: HostConnection::get() New Host Connection established 0xd633f190, tid 17142
+01-09 23:49:55.248 10254 17117 17142 D HostConnection: HostComposition ext ANDROID_EMU_CHECKSUM_HELPER_v1 ANDROID_EMU_native_sync_v2 ANDROID_EMU_native_sync_v3 ANDROID_EMU_native_sync_v4 ANDROID_EMU_dma_v1 ANDROID_EMU_direct_mem ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_YUV420_888_to_NV21 ANDROID_EMU_YUV_Cache ANDROID_EMU_async_unmap_buffer GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr ANDROID_EMU_host_side_tracing ANDROID_EMU_async_frame_commands ANDROID_EMU_gles_max_version_3_0 
+01-09 23:49:55.252 10254 17117 17142 W OpenGLRenderer: Failed to choose config with EGL_SWAP_BEHAVIOR_PRESERVED, retrying without...
+01-09 23:49:55.253 10254 17117 17142 D eglCodecCommon: setVertexArrayObject: set vao to 0 (0) 0 0
+01-09 23:49:55.253 10254 17117 17142 D EGL_emulation: eglCreateContext: 0xd631a2a0: maj 3 min 0 rcv 3
+01-09 23:49:55.264  root  1929  1929 E netmgr  : Failed to open QEMU pipe 'qemud:network': Invalid argument
+01-09 23:49:55.270 10254 17117 17142 D EGL_emulation: eglMakeCurrent: 0xd631a2a0: ver 3 0 (tinfo 0xd630f7e0)
+01-09 23:49:55.276  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.279  1000  1681  1681 I hwservicemanager: getTransport: Cannot find entry android.hardware.graphics.mapper@3.0::IMapper/default in either framework or device manifest.
+01-09 23:49:55.279 10254 17117 17142 W Gralloc3: mapper 3.x is not supported
+01-09 23:49:55.280 10254 17117 17142 D HostConnection: createUnique: call
+01-09 23:49:55.280 10254 17117 17142 D HostConnection: HostConnection::get() New Host Connection established 0xd633f2d0, tid 17142
+01-09 23:49:55.281 10254 17117 17142 D HostConnection: HostComposition ext ANDROID_EMU_CHECKSUM_HELPER_v1 ANDROID_EMU_native_sync_v2 ANDROID_EMU_native_sync_v3 ANDROID_EMU_native_sync_v4 ANDROID_EMU_dma_v1 ANDROID_EMU_direct_mem ANDROID_EMU_host_composition_v1 ANDROID_EMU_host_composition_v2 ANDROID_EMU_YUV420_888_to_NV21 ANDROID_EMU_YUV_Cache ANDROID_EMU_async_unmap_buffer GL_OES_EGL_image_external_essl3 GL_OES_vertex_array_object GL_KHR_texture_compression_astc_ldr ANDROID_EMU_host_side_tracing ANDROID_EMU_async_frame_commands ANDROID_EMU_gles_max_version_3_0 
+01-09 23:49:55.281 10254 17117 17142 D eglCodecCommon: allocate: Ask for block of size 0x1000
+01-09 23:49:55.281 10254 17117 17142 D eglCodecCommon: allocate: ioctl allocate returned offset 0x3ff7ff000 size 0x2000
+01-09 23:49:55.282  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.285  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.286 10254 17117 17142 D EGL_emulation: eglMakeCurrent: 0xd631a2a0: ver 3 0 (tinfo 0xd630f7e0)
+01-09 23:49:55.288 10254 17117 17142 D eglCodecCommon: setVertexArrayObject: set vao to 0 (0) 0 0
+01-09 23:49:55.371  1000  2027  2053 I ActivityTaskManager: Displayed com.example/.MainActivity: +296ms
+01-09 23:49:55.379 10254 17117 17117 I AssistStructure: Flattened final assist data: 736 bytes, containing 1 windows, 3 views
+01-09 23:49:55.388 10098  2534  2534 W lil     : Pending fill request while another request in the same session was triggered. [CONTEXT service_id=177 ]
+01-09 23:49:55.428  1000  2027  2817 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.429  1000  2027  2817 I chatty  : uid=1000(system) Binder:2027_10 identical 8 lines
+01-09 23:49:55.429  1000  2027  2817 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.431 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: PAUSED
+01-09 23:49:55.433  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.437  1000  2027  2815 I chatty  : uid=1000(system) Binder:2027_F identical 28 lines
+01-09 23:49:55.437  1000  2027  2815 W InputReader: Device has associated, but no associated display id.
+01-09 23:49:55.441 10090  2421  2849 D EGL_emulation: eglMakeCurrent: 0xe957fee0: ver 3 0 (tinfo 0xde4c6490)
+01-09 23:49:55.441 10110  2974  3167 D EGL_emulation: eglMakeCurrent: 0xd631b0e0: ver 3 0 (tinfo 0xd630f900)
+01-09 23:49:55.444  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 5312512
+01-09 23:49:55.452 10254 17117 17142 D EGL_emulation: eglMakeCurrent: 0xd631a2a0: ver 3 0 (tinfo 0xd630f7e0)
+01-09 23:49:55.454 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: STOPPED
+01-09 23:49:55.459 10254 17117 17117 D LifecycleMonitor: Lifecycle status change: com.example.MainActivity@b0451ef in: DESTROYED
+01-09 23:49:55.466 10254 17117 17139 I TestRunner: failed: testAlwaysFailing(com.example.AbstractFailingTest)
+01-09 23:49:55.466 10254 17117 17139 I TestRunner: ----- begin exception -----
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: java.lang.AssertionError
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.Assert.fail(Assert.java:86)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.Assert.assertTrue(Assert.java:41)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.Assert.assertTrue(Assert.java:52)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at com.example.AbstractFailingTest.testAlwaysFailing(AbstractFailingTest.kt:22)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at java.lang.reflect.Method.invoke(Native Method)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.support.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:433)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.Suite.runChild(Suite.java:128)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.Suite.runChild(Suite.java:27)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:58)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:375)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: 	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2189)
+01-09 23:49:55.467 10254 17117 17139 I TestRunner: ----- end exception -----
+01-09 23:49:55.471 10254 17117 17139 I TestRunner: finished: testAlwaysFailing(com.example.AbstractFailingTest)
+01-09 23:49:55.480  1000  2027  2812 D WindowManager: relayoutVisibleWindow: Window{ee55c84 u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity EXITING} mAnimatingExit=true, mRemoveOnExit=false, mDestroying=false
+01-09 23:49:55.480  1000  2027  2815 D WindowManager: relayoutVisibleWindow: Window{3344f1b u0 com.google.android.apps.nexuslauncher/com.google.android.apps.nexuslauncher.NexusLauncherActivity EXITING} mAnimatingExit=true, mRemoveOnExit=false, mDestroying=false
+01-09 23:49:55.484  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.489  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.493  1000  1797  1797 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.497  1000  1797  1797 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.500 10090  2421  2849 D EGL_emulation: eglMakeCurrent: 0xe957fee0: ver 3 0 (tinfo 0xde4c6490)
+01-09 23:49:55.501  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.509  1000  1797  1945 D gralloc_ranchu: gralloc_alloc: Creating ashmem region of size 8298496
+01-09 23:49:55.515  1000  2027  4636 I ActivityTaskManager: Activity reported stop, but no longer stopping: ActivityRecord{5645067 u0 com.google.android.apps.nexuslauncher/.NexusLauncherActivity t4}
+01-09 23:49:55.515 10110  2974  3167 D EGL_emulation: eglMakeCurrent: 0xd631b0e0: ver 3 0 (tinfo 0xd630f900)
+})
+TestRunEnded(elapsedTimeMillis=526, metrics={})


### PR DESCRIPTION
Fixes #14

This request is NOT encouraged to be used unless necessary due to poor architecture and performance.

Notes from source:
```java
/**
 * WARNING: the logcat field in the proto message can lead to huge memory consumption on devices as well as on the user's side.
 *
 * The logcat is read only once on the am instrument's side and the StringBuilder is uncapped. So if you have a huge logcat -
 * you'll have to transfer it via the socket and then also parse from protobuf and allocate a String in the JVM.
 *
 * The read loop catches exception and doesn't have a way to suspend until it can read the message properly.
 *
 * This needs work on the am instrument's side:
 * - proper framing support with length of the message sent first, then the actual message
 * - streaming logcat support: this should NOT be a one-shot operation, instead we can append to file while the test executes
 * - logcat command customisation: there is no way to change the format or filter at the moment, the command is hard-coded
 *
 * see frameworks/base/cmds/am/src/com/android/commands/am/Instrument.java#readLogcat
 */
```

See [Instrument.java](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/cmds/am/src/com/android/commands/am/Instrument.java;drc=master;bpv=1;bpt=1;l=560?gsn=StringBuilder&gs=kythe%3A%2F%2Fopenjdk11%3Flang%3Djava%3Fpath%3Djava.lang.StringBuilder%2330f353ef4aa6cd680b40af882b8c7ed2d262a77116c6e3f7e4d868cddfa9967d) source code