### PR TITLE
Replace default comma separator to blank

### DIFF
--- a/src/main/kotlin/com/malinskiy/adam/request/testrunner/InstrumentOptions.kt
+++ b/src/main/kotlin/com/malinskiy/adam/request/testrunner/InstrumentOptions.kt
@@ -76,6 +76,6 @@ data class InstrumentOptions(
         if (emma != null) append(" -e emma $emma")
         if (coverageFile != null) append(" -e coverageFile $coverageFile")
 
-        append(overrides.map { " -e ${it.key} ${it.value}" }.joinToString())
+        append(overrides.map { " -e ${it.key} ${it.value}" }.joinToString(""))
     }.toString()
 }

--- a/src/test/kotlin/com/malinskiy/adam/request/testrunner/InstrumentOptionsTest.kt
+++ b/src/test/kotlin/com/malinskiy/adam/request/testrunner/InstrumentOptionsTest.kt
@@ -87,4 +87,19 @@ class InstrumentOptionsTest {
         assertThat(options.performance).isEqualTo(true)
         assertThat(options.unit).isEqualTo(true)
     }
+
+    @Test
+    fun testMultipleOverrides() {
+        val options = InstrumentOptions(
+            overrides = mapOf(
+                "param1" to "value1",
+                "param2" to "value2"
+            )
+        )
+
+        assertThat(options.toString()).isEqualTo(
+            " -e param1 value1" +
+                    " -e param2 value2"
+        )
+    }
 }


### PR DESCRIPTION
`joinToString()` providing `, ` as default separator