### PR TITLE
Configure adb server port by using environment variable ANDROID_ADB_SERVER_PORT

### DIFF
--- a/adam/src/main/kotlin/com/malinskiy/adam/interactor/StartAdbInteractor.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/interactor/StartAdbInteractor.kt
@@ -24,5 +24,5 @@ class StartAdbInteractor : AdbBinaryInteractor() {
         adbBinary: File? = null,
         androidHome: File? = null,
         serverPort: Int = Const.DEFAULT_ADB_PORT
-    ) = execute(adbBinary, androidHome, "start-server", "-P", serverPort.toString())
+    ) = execute(adbBinary, androidHome, "-P", serverPort.toString(), "start-server")
 }

--- a/adam/src/main/kotlin/com/malinskiy/adam/interactor/StopAdbInteractor.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/interactor/StopAdbInteractor.kt
@@ -24,5 +24,5 @@ class StopAdbInteractor : AdbBinaryInteractor() {
         adbBinary: File? = null,
         androidHome: File? = null,
         serverPort: Int = Const.DEFAULT_ADB_PORT
-    ) = execute(adbBinary, androidHome, "kill-server", "-P", serverPort.toString())
+    ) = execute(adbBinary, androidHome, "-P", serverPort.toString(), "kill-server")
 }

--- a/adam/src/test/kotlin/com/malinskiy/adam/integration/AdbBinaryIntegrationTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/integration/AdbBinaryIntegrationTest.kt
@@ -23,15 +23,21 @@ import org.junit.Test
 
 class AdbBinaryIntegrationTest {
     @Test
-    fun testCreateAdbServer() {
+    fun testStartAndKillAdbServer() {
         val startAdbInteractor = StartAdbInteractor()
         val stopAdbInteractor = StopAdbInteractor()
+        val customServerPort = 1234
 
         runBlocking {
             startAdbInteractor.execute()
             stopAdbInteractor.execute()
             startAdbInteractor.execute()
             stopAdbInteractor.execute()
+
+            startAdbInteractor.execute(serverPort = customServerPort)
+            stopAdbInteractor.execute(serverPort = customServerPort)
+            startAdbInteractor.execute(serverPort = customServerPort)
+            stopAdbInteractor.execute(serverPort = customServerPort)
         }
 
     }


### PR DESCRIPTION
This is actually the only currently supported way of configuring adb server port (unless one want to deal with starting adb fork-server themselves).