### PR TITLE
Fixed issue with special characters not being escaped in the local path when pushing

### DIFF
--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/PushE2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/PushE2ETest.kt
@@ -91,6 +91,21 @@ class PushE2ETest {
         }
     }
 
+    @Test
+    fun testPushCreatingSubdir() {
+        val source = temp.newFolder("testdir with special 'chars()")
+        val x = File(source, "testfilex").apply { createNewFile(); writeText("Xcafebabe\n") }
+
+        runBlocking {
+            val execute =
+                adbRule.adb.execute(PushRequest(source, "/data/local/tmp", adbRule.supportedFeatures), adbRule.deviceSerial)
+
+            //Should create a subdir since dst already exists
+            assertThat(statFile("/data/local/tmp/testdir with special 'chars()").isDirectory()).isTrue()
+            assertThat(statFile("/data/local/tmp/testdir with special 'chars()/testfilex").isRegularFile()).isTrue()
+        }
+    }
+
     private suspend fun statFile(path: String) = adbRule.adb.execute(StatFileRequest(path), adbRule.deviceSerial)
 
     private suspend fun readFile(path: String) =

--- a/adam/src/main/kotlin/com/malinskiy/adam/extension/List.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/extension/List.kt
@@ -16,4 +16,4 @@
 
 package com.malinskiy.adam.extension
 
-fun List<String>.bashEscape() = "'" + joinToString(" ") { it.replace("\'", "\\'") } + "'"
+fun List<String>.bashEscape() = "'" + joinToString(" ") { it.replace("'", "'\\''") } + "'"

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/sync/PushRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/sync/PushRequest.kt
@@ -20,6 +20,7 @@ import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.Const
 import com.malinskiy.adam.annotation.Features
 import com.malinskiy.adam.exception.PushFailedException
+import com.malinskiy.adam.extension.bashEscape
 import com.malinskiy.adam.request.Feature
 import com.malinskiy.adam.request.MultiRequest
 import com.malinskiy.adam.request.shell.v1.ShellCommandRequest
@@ -171,13 +172,13 @@ class PushRequest(
         serial: String?,
         dirsToCreate: List<String>
     ) {
-        execute(ShellCommandRequest("mkdir -p ${escape(destination)}"), serial)
+        execute(ShellCommandRequest("mkdir -p ${listOf(destination).bashEscape()}"), serial)
 
         val cmdBuilder = StringBuilder()
         cmdBuilder.append("mkdir")
         val limit = 1024 * 4
         for (dir in dirsToCreate) {
-            val escapedDirArg = " ${escape(dir)}"
+            val escapedDirArg = " ${listOf(dir).bashEscape()}"
             //This check might fail for multi-byte encodings
             if (cmdBuilder.length + escapedDirArg.length > limit) {
                 execute(ShellCommandRequest(cmdBuilder.toString()), serial)
@@ -193,10 +194,6 @@ class PushRequest(
             execute(ShellCommandRequest(cmdBuilder.toString()), serial)
         }
         cmdBuilder.clear()
-    }
-
-    private fun escape(str: String): String {
-        return "\'${str.replace("'", "'\\''")}\'"
     }
 
     private suspend fun AndroidDebugBridgeClient.doPushFile(

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/sync/PushRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/sync/PushRequest.kt
@@ -171,13 +171,13 @@ class PushRequest(
         serial: String?,
         dirsToCreate: List<String>
     ) {
-        execute(ShellCommandRequest("mkdir -p $destination"), serial)
+        execute(ShellCommandRequest("mkdir -p ${escape(destination)}"), serial)
 
         val cmdBuilder = StringBuilder()
         cmdBuilder.append("mkdir")
         val limit = 1024 * 4
         for (dir in dirsToCreate) {
-            val escapedDirArg = " \'$dir\'"
+            val escapedDirArg = " ${escape(dir)}"
             //This check might fail for multi-byte encodings
             if (cmdBuilder.length + escapedDirArg.length > limit) {
                 execute(ShellCommandRequest(cmdBuilder.toString()), serial)
@@ -193,6 +193,10 @@ class PushRequest(
             execute(ShellCommandRequest(cmdBuilder.toString()), serial)
         }
         cmdBuilder.clear()
+    }
+
+    private fun escape(str: String): String {
+        return "\'${str.replace("'", "'\\''")}\'"
     }
 
     private suspend fun AndroidDebugBridgeClient.doPushFile(


### PR DESCRIPTION
When creating a directory on the device it was passing `path.name`
directly to `mkdir` without escaping it. This causes issues with
characters that are interpreted specially with the shell.