### PR TITLE
fix(adam): fix vertx socket factory crash during shutdown

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    val adam = System.getenv("GIT_TAG_NAME") ?: "0.4.3"
+    val adam = System.getenv("GIT_TAG_NAME") ?: "0.4.5"
     val kotlin = "1.6.10"
     val coroutines = "1.6.0"
     val coroutinesDebug = coroutines


### PR DESCRIPTION
during shutdown currently close of the socket factory might initialise the vertx object. this in turn adds a new shutdown hook which is impossible during the shutdown.
Check if the vertx has been initialised before accessing the property