### PR TITLE
fix windows detection

### DIFF
--- a/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
@@ -33,8 +33,9 @@ open class AdbBinaryInteractor {
         }?.let { File(it) }
 
         val os = System.getProperty("os.name").lowercase(Locale.ENGLISH)
+        val isWindows = os.contains("win")
         val adbBinaryName = when {
-            os.contains("win") -> {
+            isWindows -> {
                 "adb.exe"
             }
             else -> "adb"
@@ -44,7 +45,7 @@ open class AdbBinaryInteractor {
             adbBinary != null -> adbBinary
             androidHome != null -> File(androidHome, "platform-tools" + File.separator + adbBinaryName)
             androidEnvHome != null -> File(androidEnvHome, "platform-tools" + File.separator + adbBinaryName)
-            else -> discoverAdbBinary(os)
+            else -> discoverAdbBinary(isWindows)
         }
         if (adb?.isFile != true) return false
 
@@ -61,8 +62,8 @@ open class AdbBinaryInteractor {
         }
     }
 
-    private fun discoverAdbBinary(os: String): File? {
-        val discoverCommand = if (os == "win") "where" else "which"
+    private fun discoverAdbBinary(isWindows: Boolean): File? {
+        val discoverCommand = if (isWindows) "where" else "which"
         val builder = ProcessBuilder(discoverCommand, "adb").inheritIO()
         val process = builder.start()
         process.waitFor()

--- a/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
@@ -64,7 +64,7 @@ open class AdbBinaryInteractor {
 
     private fun discoverAdbBinary(isWindows: Boolean): File? {
         val discoverCommand = if (isWindows) "where" else "which"
-        val builder = ProcessBuilder(discoverCommand, "adb").inheritIO()
+        val builder = ProcessBuilder(discoverCommand, "adb")
         val process = builder.start()
         process.waitFor()
 

--- a/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
@@ -64,7 +64,8 @@ open class AdbBinaryInteractor {
 
     private fun discoverAdbBinary(isWindows: Boolean): File? {
         val discoverCommand = if (isWindows) "where" else "which"
-        val builder = ProcessBuilder(discoverCommand, "adb")
+        val builder = ProcessBuilder(discoverCommand, "adb").inheritIO()
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
         val process = builder.start()
         process.waitFor()
 

--- a/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/interactor/AdbBinaryInteractor.kt
@@ -69,10 +69,14 @@ open class AdbBinaryInteractor {
         val process = builder.start()
         process.waitFor()
 
-        return process.takeIf { it.exitValue() == 0 }
-            ?.inputStream
-            ?.bufferedReader()
-            ?.readLine()
-            ?.let(::File)
+        return if (process.exitValue() == 0) {
+            process.inputStream
+                .bufferedReader()
+                .readLine()
+                .let(::File)
+        } else {
+            process.inputStream.close()
+            null
+        }
     }
 }


### PR DESCRIPTION
The argument to `discoverAdbBinary` was the string `windows 11`.
"windows 11" == "win" was false.

Fixed an issue where `inheritIO` could not get from InputStream.