### PR TITLE
fix(adam): test runner should read only stdout if possible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: macOS-10.15
     strategy:
       matrix:
-        api: [ 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33 ]
+        api: [ 21, 22, 23, 24, 25, 26, 28, 29, 30, 31, 33 ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK 11
@@ -55,7 +55,7 @@ jobs:
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -cores 2 -memory 3072 -no-window -gpu swiftshader_indirect
           api: ${{ matrix.api }}
           tag: google_apis
-          abi: x86
+          abi: x86_64
       - name: Generate integration code coverage report
         run: ./gradlew :adam:jacocoIntegrationTestReport
       - name: archive integration test results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: macOS-10.15
     strategy:
       matrix:
-        api: [ 21, 22, 23, 24, 25, 26, 27, 28, 29, 30 ]
+        api: [ 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33 ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK 11

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,11 @@ jobs:
       - uses: malinskiy/action-android/install-sdk@release/0.1.1
       - name: build & test
         run: ./gradlew assemble test jacocoTestReport
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: archive test results
         if: failure()
         run: (cd adam/build/reports/tests/test; zip -r -X ../../../../../test-result.zip .)
@@ -56,6 +61,11 @@ jobs:
           api: ${{ matrix.api }}
           tag: google_apis
           abi: x86_64
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/integrationTest/TEST-*.xml'
       - name: Generate integration code coverage report
         run: ./gradlew :adam:jacocoIntegrationTestReport
       - name: archive integration test results

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/E2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/E2ETest.kt
@@ -22,6 +22,7 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.startsWith
+import com.malinskiy.adam.Const
 import com.malinskiy.adam.request.device.FetchDeviceFeaturesRequest
 import com.malinskiy.adam.request.device.ListDevicesRequest
 import com.malinskiy.adam.request.framebuffer.RawImageScreenCaptureAdapter
@@ -76,7 +77,12 @@ class E2ETest {
                 ShellCommandRequest("echo hello"),
                 adbRule.deviceSerial
             )
-            assertThat(response).isEqualTo(ShellCommandResult("hello${adbRule.lineSeparator}", 0))
+            assertThat(response).isEqualTo(
+                ShellCommandResult(
+                    "hello${adbRule.lineSeparator}".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING),
+                    0
+                )
+            )
         }
     }
 

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
@@ -42,8 +42,8 @@ class ShellV2E2ETest {
     fun testDefault() = runBlocking {
         val result = adbRule.adb.execute(ShellCommandRequest("echo foo; echo bar >&2; exit 17"), adbRule.deviceSerial)
         assertThat(result.exitCode).isEqualTo(17)
-        assertThat(result.stdout).isEqualTo("foo\n")
-        assertThat(result.stderr).isEqualTo("bar\n")
+        assertThat(result.output).isEqualTo("foo\n")
+        assertThat(result.errorOutput).isEqualTo("bar\n")
     }
 
     @Test
@@ -69,8 +69,8 @@ class ShellV2E2ETest {
         val stderrBuilder = StringBuilder()
         var exitCode = 1
         for (i in receiveChannel) {
-            i.stdout?.let { stdoutBuilder.append(it) }
-            i.stderr?.let { stderrBuilder.append(it) }
+            i.stdout?.let { stdoutBuilder.append(String(it, Const.DEFAULT_TRANSPORT_ENCODING)) }
+            i.stderr?.let { stderrBuilder.append(String(it, Const.DEFAULT_TRANSPORT_ENCODING)) }
             i.exitCode?.let { exitCode = it }
         }
         stdioJob.join()

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
@@ -19,6 +19,7 @@ package com.malinskiy.adam.integration
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import com.malinskiy.adam.Const
 import com.malinskiy.adam.request.Feature
 import com.malinskiy.adam.request.shell.v2.ChanneledShellCommandRequest
 import com.malinskiy.adam.request.shell.v2.ShellCommandInputChunk
@@ -53,7 +54,7 @@ class ShellV2E2ETest {
         val stdioJob = launch(Dispatchers.IO) {
             stdio.send(
                 ShellCommandInputChunk(
-                    stdin = "cafebabe"
+                    stdin = "cafebabe".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
                 )
             )
 

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/TestRunnerE2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/TestRunnerE2ETest.kt
@@ -78,9 +78,11 @@ class TestRunnerE2ETest {
                     "com.example.test",
                     InstrumentOptions(
                         clazz = listOf("com.example.AbstractFailingTest")
-                    )
-                ), serial = rule.deviceSerial,
-                scope = this
+                    ),
+                    rule.supportedFeatures,
+                    this
+                ),
+                serial = rule.deviceSerial,
             )
 
             val events = mutableListOf<TestEvent>()
@@ -113,9 +115,11 @@ class TestRunnerE2ETest {
                     InstrumentOptions(
                         clazz = listOf("com.example.AbstractFailingTest")
                     ),
-                    protobuf = true
-                ), serial = rule.deviceSerial,
-                scope = this
+                    rule.supportedFeatures,
+                    this,
+                    protobuf = true,
+                ),
+                serial = rule.deviceSerial,
             )
 
             val events = mutableListOf<TestEvent>()

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/feature/AbbE2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/feature/AbbE2ETest.kt
@@ -35,7 +35,7 @@ class AbbE2ETest {
     fun testStreamingInstallRequest() {
         runBlocking {
             var result = adbRule.adb.execute(AbbRequest(listOf("-l"), adbRule.supportedFeatures), serial = adbRule.deviceSerial)
-            assertThat(result.stdout).startsWith("Currently running services:")
+            assertThat(result.output).startsWith("Currently running services:")
         }
     }
 }

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/shell/AsyncCompatShellCommandRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/shell/AsyncCompatShellCommandRequest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.request.shell
+
+import com.malinskiy.adam.AndroidDebugBridgeClient
+import com.malinskiy.adam.Const
+import com.malinskiy.adam.request.Feature
+import com.malinskiy.adam.request.MultiRequest
+import com.malinskiy.adam.request.NonSpecifiedTarget
+import com.malinskiy.adam.request.Target
+import com.malinskiy.adam.request.shell.v1.ChanneledShellCommandRequest
+import com.malinskiy.adam.request.shell.v2.ShellCommandInputChunk
+import com.malinskiy.adam.request.shell.v2.ShellCommandResultChunk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.produce
+import com.malinskiy.adam.request.shell.v2.ChanneledShellCommandRequest as V2ChanneledShellCommandRequest
+
+abstract class AsyncCompatShellCommandRequest<T : Any>(
+    val cmd: String,
+    private val supportedFeatures: List<Feature>,
+    private val target: Target = NonSpecifiedTarget,
+    private val coroutineScope: CoroutineScope,
+    private val socketIdleTimeout: Long? = null,
+) : MultiRequest<ReceiveChannel<T>>() {
+
+    abstract suspend fun convertChunk(response: ShellCommandResultChunk): T?
+
+    override suspend fun execute(
+        androidDebugBridgeClient: AndroidDebugBridgeClient,
+        serial: String?
+    ): ReceiveChannel<T> {
+        return when {
+            supportedFeatures.contains(Feature.SHELL_V2) -> {
+                val channel = Channel<ShellCommandInputChunk>()
+                val receiveChannel = androidDebugBridgeClient.execute(
+                    V2ChanneledShellCommandRequest(cmd, channel, target, socketIdleTimeout), coroutineScope, serial,
+                )
+                coroutineScope.produce {
+                    for (chunk in receiveChannel) {
+                        convertChunk(chunk)?.let { send(it) }
+                    }
+                    this@AsyncCompatShellCommandRequest.close(this.channel)
+                }
+            }
+
+            else -> {
+                val receiveChannel: ReceiveChannel<String> = androidDebugBridgeClient.execute(
+                    ChanneledShellCommandRequest(cmd, target, socketIdleTimeout), coroutineScope, serial,
+                )
+                coroutineScope.produce {
+                    for (line in receiveChannel) {
+                        val chunk = ShellCommandResultChunk(stdout = line.toByteArray(Const.DEFAULT_TRANSPORT_ENCODING))
+                        convertChunk(chunk)?.let { send(it) }
+                    }
+                    this@AsyncCompatShellCommandRequest.close(this.channel)
+                }
+            }
+        }
+    }
+
+    abstract suspend fun close(channel: SendChannel<T>)
+}

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v1/ShellCommandResult.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v1/ShellCommandResult.kt
@@ -16,7 +16,31 @@
 
 package com.malinskiy.adam.request.shell.v1
 
+import com.malinskiy.adam.Const
+
 data class ShellCommandResult(
-    val output: String,
+    val stdout: ByteArray,
     val exitCode: Int
-)
+) {
+    val output: String by lazy {
+        String(stdout, Const.DEFAULT_TRANSPORT_ENCODING)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ShellCommandResult
+
+        if (!stdout.contentEquals(other.stdout)) return false
+        if (exitCode != other.exitCode) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = stdout.contentHashCode()
+        result = 31 * result + exitCode
+        return result
+    }
+}

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/ChanneledShellCommandRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/ChanneledShellCommandRequest.kt
@@ -16,35 +16,41 @@
 
 package com.malinskiy.adam.request.shell.v2
 
-import com.malinskiy.adam.Const
 import com.malinskiy.adam.request.AsyncChannelRequest
 import com.malinskiy.adam.request.NonSpecifiedTarget
 import com.malinskiy.adam.request.Target
 import com.malinskiy.adam.transport.Socket
-import com.malinskiy.adam.transport.withMaxPacketBuffer
+import com.malinskiy.adam.transport.withMaxFilePacketBuffer
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 
 open class ChanneledShellCommandRequest(
     private val cmd: String,
     channel: ReceiveChannel<ShellCommandInputChunk>,
-    target: Target = NonSpecifiedTarget
-) : AsyncChannelRequest<ShellCommandResultChunk, ShellCommandInputChunk>(target = target, channel = channel) {
+    target: Target = NonSpecifiedTarget,
+    socketIdleTimeout: Long? = null,
+) : AsyncChannelRequest<ShellCommandResultChunk, ShellCommandInputChunk>(
+    target = target,
+    channel = channel,
+    socketIdleTimeout = socketIdleTimeout
+) {
 
     override suspend fun readElement(socket: Socket, sendChannel: SendChannel<ShellCommandResultChunk>): Boolean {
-        withMaxPacketBuffer {
+        withMaxFilePacketBuffer {
             val data = array()
             when (MessageType.of(socket.readByte().toInt())) {
                 MessageType.STDOUT -> {
                     val length = socket.readIntLittleEndian()
                     socket.readFully(data, 0, length)
-                    sendChannel.send(ShellCommandResultChunk(stdout = String(data, 0, length, Const.DEFAULT_TRANSPORT_ENCODING)))
+                    sendChannel.send(ShellCommandResultChunk(stdout = data.copyOfRange(0, length)))
                 }
+
                 MessageType.STDERR -> {
                     val length = socket.readIntLittleEndian()
                     socket.readFully(data, 0, length)
-                    sendChannel.send(ShellCommandResultChunk(stderr = String(data, 0, length, Const.DEFAULT_TRANSPORT_ENCODING)))
+                    sendChannel.send(ShellCommandResultChunk(stderr = data.copyOfRange(0, length)))
                 }
+
                 MessageType.EXIT -> {
                     //ignoredLength
                     socket.readIntLittleEndian()
@@ -52,6 +58,7 @@ open class ChanneledShellCommandRequest(
                     sendChannel.send(ShellCommandResultChunk(exitCode = exitCode))
                     return true
                 }
+
                 else -> Unit
             }
 
@@ -63,9 +70,8 @@ open class ChanneledShellCommandRequest(
      * Handles stdin
      */
     override suspend fun writeElement(element: ShellCommandInputChunk, socket: Socket) {
-        element.stdin?.let {
+        element.stdin?.let { bytes ->
             socket.writeByte(MessageType.STDIN.toValue())
-            val bytes = it.toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
             socket.writeIntLittleEndian(bytes.size)
             socket.writeFully(bytes)
         }
@@ -80,12 +86,59 @@ open class ChanneledShellCommandRequest(
 }
 
 data class ShellCommandResultChunk(
-    val stdout: String? = null,
-    val stderr: String? = null,
+    val stdout: ByteArray? = null,
+    val stderr: ByteArray? = null,
     val exitCode: Int? = null
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ShellCommandResultChunk
+
+        if (stdout != null) {
+            if (other.stdout == null) return false
+            if (!stdout.contentEquals(other.stdout)) return false
+        } else if (other.stdout != null) return false
+        if (stderr != null) {
+            if (other.stderr == null) return false
+            if (!stderr.contentEquals(other.stderr)) return false
+        } else if (other.stderr != null) return false
+        if (exitCode != other.exitCode) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = stdout?.contentHashCode() ?: 0
+        result = 31 * result + (stderr?.contentHashCode() ?: 0)
+        result = 31 * result + (exitCode ?: 0)
+        return result
+    }
+}
 
 data class ShellCommandInputChunk(
-    val stdin: String? = null,
+    val stdin: ByteArray? = null,
     val close: Boolean = false
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ShellCommandInputChunk
+
+        if (stdin != null) {
+            if (other.stdin == null) return false
+            if (!stdin.contentEquals(other.stdin)) return false
+        } else if (other.stdin != null) return false
+        if (close != other.close) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = stdin?.contentHashCode() ?: 0
+        result = 31 * result + close.hashCode()
+        return result
+    }
+}

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/ShellCommandResult.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/ShellCommandResult.kt
@@ -16,8 +16,38 @@
 
 package com.malinskiy.adam.request.shell.v2
 
+import com.malinskiy.adam.Const
+
 data class ShellCommandResult(
-    val stdout: String,
-    val stderr: String,
+    val stdout: ByteArray,
+    val stderr: ByteArray,
     val exitCode: Int
-)
+) {
+    val output: String by lazy {
+        String(stdout, Const.DEFAULT_TRANSPORT_ENCODING)
+    }
+
+    val errorOutput: String by lazy {
+        String(stderr, Const.DEFAULT_TRANSPORT_ENCODING)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ShellCommandResult
+
+        if (!stdout.contentEquals(other.stdout)) return false
+        if (!stderr.contentEquals(other.stderr)) return false
+        if (exitCode != other.exitCode) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = stdout.contentHashCode()
+        result = 31 * result + stderr.contentHashCode()
+        result = 31 * result + exitCode
+        return result
+    }
+}

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequest.kt
@@ -22,7 +22,6 @@ import com.malinskiy.adam.request.shell.v2.ShellCommandResultChunk
 import com.malinskiy.adam.request.transform.InstrumentationResponseTransformer
 import com.malinskiy.adam.request.transform.ProgressiveResponseTransformer
 import com.malinskiy.adam.request.transform.ProtoInstrumentationResponseTransformer
-import com.malinskiy.adam.transport.AdamMaxFilePacketPool
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.SendChannel
 
@@ -102,7 +101,6 @@ class TestRunnerRequest(
     coroutineScope = coroutineScope,
     socketIdleTimeout = socketIdleTimeout,
 ) {
-    private val buffer = AdamMaxFilePacketPool.borrow()
     private val transformer: ProgressiveResponseTransformer<List<TestEvent>?> by lazy {
         if (protobuf) {
             ProtoInstrumentationResponseTransformer()
@@ -116,7 +114,6 @@ class TestRunnerRequest(
             transformer.process(bytes, 0, bytes.size)
         }
     }
-
 
     override suspend fun close(channel: SendChannel<List<TestEvent>>) {
         transformer.transform()?.let { channel.send(it) }

--- a/adam/src/test/kotlin/com/malinskiy/adam/request/shell/v2/ChanneledShellCommandRequestTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/request/shell/v2/ChanneledShellCommandRequestTest.kt
@@ -19,6 +19,7 @@ package com.malinskiy.adam.request.shell.v2
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.malinskiy.adam.AndroidDebugBridgeClient
+import com.malinskiy.adam.Const
 import com.malinskiy.adam.server.junit4.AdbServerRule
 import io.ktor.utils.io.discard
 import kotlinx.coroutines.Dispatchers
@@ -66,14 +67,14 @@ class ChanneledShellCommandRequestTest {
             var exitCode = -1
 
             withContext(Dispatchers.IO) {
-                stdio.send(ShellCommandInputChunk("cafebabe"))
+                stdio.send(ShellCommandInputChunk("cafebabe".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)))
                 stdio.send(ShellCommandInputChunk(close = true))
             }
 
             for (msg in updates) {
-                if (msg.stdout != null) stdoutBuffer.append(msg.stdout)
-                if (msg.stderr != null) stderrBuffer.append(msg.stderr)
-                if (msg.exitCode != null) exitCode = msg.exitCode!!
+                msg.stdout?.let { stdoutBuffer.append(String(it, Const.DEFAULT_TRANSPORT_ENCODING)) }
+                msg.stderr?.let { stderrBuffer.append(String(it, Const.DEFAULT_TRANSPORT_ENCODING)) }
+                msg.exitCode?.let { exitCode = it }
             }
 
             assertThat(stdoutBuffer.toString()).isEqualTo("foo\n")

--- a/adam/src/test/kotlin/com/malinskiy/adam/request/shell/v2/ShellCommandRequestTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/request/shell/v2/ShellCommandRequestTest.kt
@@ -47,8 +47,8 @@ class ShellCommandRequestTest {
 
 
             val output = client.execute(ShellCommandRequest("echo foo; echo bar >&2; exit 17"), serial = "serial")
-            assertThat(output.stdout).isEqualTo("foo\n")
-            assertThat(output.stderr).isEqualTo("bar\n")
+            assertThat(output.output).isEqualTo("foo\n")
+            assertThat(output.errorOutput).isEqualTo("bar\n")
             assertThat(output.exitCode).isEqualTo(17)
         }
     }

--- a/adam/src/test/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequestTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequestTest.kt
@@ -285,7 +285,6 @@ class TestRunnerRequestTest {
         }
     }
 
-    @Ignore
     @Test
     fun testReturnsContentOnFailure() {
         runBlocking {
@@ -314,36 +313,6 @@ class TestRunnerRequestTest {
 
                 assertThat(events).containsOnly(TestRunFailed("No test results\nsomething-something"))
             }.join()
-        }
-    }
-
-    @Ignore
-    @Test
-    fun testChannelIsEmpty() {
-        runBlocking {
-            launch {
-                server.session {
-                    expectCmd { "host:transport:serial" }.accept()
-                    input.discard()
-                }
-
-                val request = TestRunnerRequest(
-                    testPackage = "com.example.test",
-                    instrumentOptions = InstrumentOptions(),
-                    supportedFeatures = emptyList(),
-                    coroutineScope = this
-                )
-                val execute = client.execute(request, "serial")
-
-                var events = mutableListOf<TestEvent>()
-                while (!execute.isClosedForReceive) {
-                    events.addAll(execute.receiveCatching().getOrNull() ?: break)
-                }
-
-                assertThat(events).isEqualTo(1.0)
-            }.join()
-
-//            assertThat(tempFile.readBytes()).isEqualTo(fixture.readBytes())
         }
     }
 }

--- a/adam/src/test/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequestTest.kt
+++ b/adam/src/test/kotlin/com/malinskiy/adam/request/testrunner/TestRunnerRequestTest.kt
@@ -17,20 +17,16 @@
 package com.malinskiy.adam.request.testrunner
 
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.containsOnly
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import com.malinskiy.adam.AndroidDebugBridgeClient
-import com.malinskiy.adam.Const
+import com.malinskiy.adam.request.Feature
 import com.malinskiy.adam.server.junit4.AdbServerRule
-import com.malinskiy.adam.server.stub.StubSocket
-import com.malinskiy.adam.transport.use
-import io.ktor.utils.io.ByteChannel
-import io.ktor.utils.io.close
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import io.ktor.utils.io.discard
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -42,38 +38,254 @@ class TestRunnerRequestTest {
 
     @Test
     fun testSerialize() {
-        val request = TestRunnerRequest(
-            testPackage = "com.example.test",
-            noWindowAnimations = true,
-            instrumentOptions = InstrumentOptions(),
-            abi = "x86",
-            noHiddenApiChecks = true,
-            outputLogPath = "/sdcard/log",
-            profilingOutputPath = "/sdcard/profiling",
-            runnerClass = "com.example.test.AndroidTestRunner",
-            userId = 1000
-        )
-
-        assertThat(String(request.serialize(), Const.DEFAULT_TRANSPORT_ENCODING))
-            .isEqualTo(
-                "00B4shell:am instrument -w -r --no-hidden-api-checks --no-window-animation --user 1000 --abi x86 " +
-                        "-p /sdcard/profiling -f /sdcard/log com.example.test/com.example.test.AndroidTestRunner"
+        runBlocking {
+            val request = TestRunnerRequest(
+                testPackage = "com.example.test",
+                noWindowAnimations = true,
+                instrumentOptions = InstrumentOptions(),
+                abi = "x86",
+                noHiddenApiChecks = true,
+                outputLogPath = "/sdcard/log",
+                profilingOutputPath = "/sdcard/profiling",
+                runnerClass = "com.example.test.AndroidTestRunner",
+                userId = 1000,
+                supportedFeatures = emptyList(),
+                coroutineScope = this
             )
+
+            assertThat(request.cmd)
+                .isEqualTo(
+                    "am instrument -w -r --no-hidden-api-checks --no-window-animation --user 1000 --abi x86 " +
+                            "-p /sdcard/profiling -f /sdcard/log com.example.test/com.example.test.AndroidTestRunner"
+                )
+        }
     }
 
     @Test
     fun testDefaultSerialize() {
-        val request = TestRunnerRequest(
-            testPackage = "com.example.test",
-            instrumentOptions = InstrumentOptions()
-        )
-
-        assertThat(String(request.serialize(), Const.DEFAULT_TRANSPORT_ENCODING))
-            .isEqualTo(
-                "0059shell:am instrument -w -r com.example.test/android.support.test.runner.AndroidJUnitRunner"
+        runBlocking {
+            val request = TestRunnerRequest(
+                testPackage = "com.example.test",
+                instrumentOptions = InstrumentOptions(),
+                supportedFeatures = emptyList(),
+                coroutineScope = this
             )
+
+            assertThat(request.cmd)
+                .isEqualTo(
+                    "am instrument -w -r com.example.test/android.support.test.runner.AndroidJUnitRunner"
+                )
+        }
     }
 
+    @Test
+    fun testV1() {
+        runBlocking {
+            launch {
+                server.session {
+                    expectCmd { "host:transport:serial" }.accept()
+                    expectShell { "am instrument -w -r com.example.test/android.support.test.runner.AndroidJUnitRunner" }
+                        .accept()
+                        .respond(
+                            """
+                            INSTRUMENTATION_STATUS: class=com.example.MainActivityAllureTest
+                            INSTRUMENTATION_STATUS: current=1
+                            INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+                            INSTRUMENTATION_STATUS: numtests=1
+                            INSTRUMENTATION_STATUS: stream=
+                            com.example.MainActivityAllureTest:
+                            INSTRUMENTATION_STATUS: test=testText
+                            INSTRUMENTATION_STATUS_CODE: 1
+                            INSTRUMENTATION_STATUS: class=com.example.MainActivityAllureTest
+                            INSTRUMENTATION_STATUS: current=1
+                            INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+                            INSTRUMENTATION_STATUS: numtests=1
+                            INSTRUMENTATION_STATUS: stream=.
+                            INSTRUMENTATION_STATUS: test=testText
+                            INSTRUMENTATION_STATUS_CODE: 0
+                            INSTRUMENTATION_RESULT: stream=
+
+                            Time: 0.915
+
+                            OK (1 test)
+
+
+                            INSTRUMENTATION_CODE: -1
+                        """.trimIndent()
+                        )
+                }
+
+                val channel = client.execute(
+                    TestRunnerRequest(
+                        testPackage = "com.example.test",
+                        instrumentOptions = InstrumentOptions(),
+                        supportedFeatures = emptyList(),
+                        coroutineScope = this
+                    ),
+                    serial = "serial",
+                )
+                val events = mutableListOf<TestEvent>()
+                while (!channel.isClosedForReceive) {
+                    val chunk = channel.receiveCatching().getOrNull() ?: break
+                    events.addAll(chunk)
+                }
+
+                assertThat(events).containsExactly(
+                    TestRunStartedEvent(testCount = 1),
+                    TestStarted(id = TestIdentifier(className = "com.example.MainActivityAllureTest", testName = "testText")),
+                    TestEnded(
+                        id = TestIdentifier(className = "com.example.MainActivityAllureTest", testName = "testText"),
+                        metrics = emptyMap()
+                    ),
+                    TestRunEnded(elapsedTimeMillis = 0, metrics = emptyMap())
+                )
+            }.join()
+        }
+    }
+
+    @Test
+    fun testV2() {
+        runBlocking {
+            launch {
+                server.session {
+                    expectCmd { "host:transport:serial" }.accept()
+                    expectShellV2 { "am instrument -w -r com.example.test/android.support.test.runner.AndroidJUnitRunner" }
+                        .accept()
+                        .respondStdout(
+                            """
+                            INSTRUMENTATION_STATUS: class=com.example.MainActivityAllureTest
+                            INSTRUMENTATION_STATUS: current=1
+                            INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+                            INSTRUMENTATION_STATUS: numtests=1
+                            INSTRUMENTATION_STATUS: stream=
+                            com.example.MainActivityAllureTest:
+                            INSTRUMENTATION_STATUS: test=testText
+                            INSTRUMENTATION_STATUS_CODE: 1
+                            INSTRUMENTATION_STATUS: class=com.example.MainActivityAllureTest
+                            INSTRUMENTATION_STATUS: current=1
+                            INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+                            INSTRUMENTATION_STATUS: numtests=1
+                            INSTRUMENTATION_STATUS: stream=.
+                            INSTRUMENTATION_STATUS: test=testText
+                            INSTRUMENTATION_STATUS_CODE: 0
+                            INSTRUMENTATION_RESULT: stream=
+
+                            Time: 0.915
+
+                            OK (1 test)
+
+
+                            INSTRUMENTATION_CODE: -1
+                        """.trimIndent()
+                        )
+                        .respondExit(0)
+                }
+
+                val channel = client.execute(
+                    TestRunnerRequest(
+                        testPackage = "com.example.test",
+                        instrumentOptions = InstrumentOptions(),
+                        supportedFeatures = listOf(Feature.SHELL_V2),
+                        coroutineScope = this
+                    ),
+                    serial = "serial",
+                )
+                val events = mutableListOf<TestEvent>()
+                while (!channel.isClosedForReceive) {
+                    val chunk = channel.receiveCatching().getOrNull() ?: break
+                    events.addAll(chunk)
+                }
+
+                assertThat(events).containsExactly(
+                    TestRunStartedEvent(testCount = 1),
+                    TestStarted(id = TestIdentifier(className = "com.example.MainActivityAllureTest", testName = "testText")),
+                    TestEnded(
+                        id = TestIdentifier(className = "com.example.MainActivityAllureTest", testName = "testText"),
+                        metrics = emptyMap()
+                    ),
+                    TestRunEnded(elapsedTimeMillis = 0, metrics = emptyMap())
+                )
+            }.join()
+        }
+    }
+
+    @Test
+    fun testV2IgnoresStderr() {
+        runBlocking {
+            launch {
+                server.session {
+                    expectCmd { "host:transport:serial" }.accept()
+                    expectShellV2 { "am instrument -w -r com.example.test/android.support.test.runner.AndroidJUnitRunner" }
+                        .accept()
+                        .respondStdout(
+                            """
+                            INSTRUMENTATION_STATUS: class=com.example.MainActivityAllureTest
+                            INSTRUMENTATION_STATUS: current=1
+                            INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+                            INSTRUMENTATION_STATUS: numtests=1
+                            INSTRUMENTATION_STATUS: stream=
+                            com.example.MainActivityAllureTest:
+                            INSTRUMENTATION_STATUS: test=testText                          
+                        """.trimIndent()
+                        )
+                        .respondStderr(
+                            """
+                            s_glBindAttribLocation: bind attrib 0 name position
+                            s_glBindAttribLocation: bind attrib 1 name localCoord
+                        """.trimIndent()
+                        )
+                        .respondStdout(
+                            """
+                                
+                            INSTRUMENTATION_STATUS_CODE: 1
+                            INSTRUMENTATION_STATUS: class=com.example.MainActivityAllureTest
+                            INSTRUMENTATION_STATUS: current=1
+                            INSTRUMENTATION_STATUS: id=AndroidJUnitRunner
+                            INSTRUMENTATION_STATUS: numtests=1
+                            INSTRUMENTATION_STATUS: stream=.
+                            INSTRUMENTATION_STATUS: test=testText
+                            INSTRUMENTATION_STATUS_CODE: 0
+                            INSTRUMENTATION_RESULT: stream=
+
+                            Time: 0.915
+
+                            OK (1 test)
+
+
+                            INSTRUMENTATION_CODE: -1
+                        """.trimIndent()
+                        )
+                        .respondExit(0)
+                }
+
+                val channel = client.execute(
+                    TestRunnerRequest(
+                        testPackage = "com.example.test",
+                        instrumentOptions = InstrumentOptions(),
+                        supportedFeatures = listOf(Feature.SHELL_V2),
+                        coroutineScope = this
+                    ),
+                    serial = "serial",
+                )
+                val events = mutableListOf<TestEvent>()
+                for (chunk in channel) {
+                    events.addAll(chunk)
+                }
+
+                assertThat(events).containsExactly(
+                    TestRunStartedEvent(testCount = 1),
+                    TestStarted(id = TestIdentifier(className = "com.example.MainActivityAllureTest", testName = "testText")),
+                    TestEnded(
+                        id = TestIdentifier(className = "com.example.MainActivityAllureTest", testName = "testText"),
+                        metrics = emptyMap()
+                    ),
+                    TestRunEnded(elapsedTimeMillis = 0, metrics = emptyMap())
+                )
+            }.join()
+        }
+    }
+
+    @Ignore
     @Test
     fun testReturnsContentOnFailure() {
         runBlocking {
@@ -86,9 +298,13 @@ class TestRunnerRequestTest {
                 }
 
                 val channel = client.execute(
-                    TestRunnerRequest("com.example.test", InstrumentOptions()),
+                    TestRunnerRequest(
+                        testPackage = "com.example.test",
+                        instrumentOptions = InstrumentOptions(),
+                        supportedFeatures = emptyList(),
+                        coroutineScope = this
+                    ),
                     serial = "serial",
-                    scope = this
                 )
                 val events = mutableListOf<TestEvent>()
                 while (!channel.isClosedForReceive) {
@@ -101,17 +317,33 @@ class TestRunnerRequestTest {
         }
     }
 
+    @Ignore
     @Test
     fun testChannelIsEmpty() {
-        val request = TestRunnerRequest("com.example.test", InstrumentOptions())
         runBlocking {
-            StubSocket(ByteChannel(autoFlush = true).apply { close() }, ByteChannel(autoFlush = true)).use { socket ->
-                val channel = Channel<List<TestEvent>>(BUFFERED)
-                val readElement = request.readElement(socket, channel)
-                val actual = channel.tryReceive()
-                assertThat(actual.isSuccess).isFalse()
-                assertThat(actual.getOrNull()).isEqualTo(null)
-            }
+            launch {
+                server.session {
+                    expectCmd { "host:transport:serial" }.accept()
+                    input.discard()
+                }
+
+                val request = TestRunnerRequest(
+                    testPackage = "com.example.test",
+                    instrumentOptions = InstrumentOptions(),
+                    supportedFeatures = emptyList(),
+                    coroutineScope = this
+                )
+                val execute = client.execute(request, "serial")
+
+                var events = mutableListOf<TestEvent>()
+                while (!execute.isClosedForReceive) {
+                    events.addAll(execute.receiveCatching().getOrNull() ?: break)
+                }
+
+                assertThat(events).isEqualTo(1.0)
+            }.join()
+
+//            assertThat(tempFile.readBytes()).isEqualTo(fixture.readBytes())
         }
     }
 }

--- a/docs/_docs/instrumentation/test-runner.md
+++ b/docs/_docs/instrumentation/test-runner.md
@@ -10,27 +10,34 @@ nav_order: 6
 1. TOC
 {:toc}
 
+Optionally uses Feature.SHELL_V2
+{: .label .label-blue }
 
 Executing tests can be done using the `TestRunnerRequest`:
 
 ```kotlin
 val channel: ReceiveChannel<List<TestEvents>> = adb.execute(
-                    request = TestRunnerRequest(
-                                  testPackage = "com.example.test",
-                                  instrumentOptions = InstrumentOptions(
-                                      clazz = listOf("com.example.MyTest")
-                                  )
-                              ),
-                    scope = GlobalScope,
-                    serial = "emulator-5554"
-                )
+ request = TestRunnerRequest(
+  testPackage = "com.example.test",
+  instrumentOptions = InstrumentOptions(
+   clazz = listOf("com.example.MyTest")
+  ),
+  supportedFeatures = emptyList(),
+  coroutineScope = GlobalScope,
+ ),
+ serial = "emulator-5554"
+)
 
 ```
 
 The result is a channel `ReadChannel<List<TestEvents>>` that contains parsed and converted output of the `am instrument` command.
 
 ### Required parameters
-To execute tests you have to provide the `testPackage` and default `InstrumentOptions()`
+
+To execute tests you have to provide the `testPackage`, default `InstrumentOptions()`, `coroutineScope` and `supportedFeatures` for the
+target device.
+Caution: you have to provide the `supportedFeatures` because newer Android devices write information into the stderr for some reason.
+The textual am instrument parser doesn't support this and needs to read only stdout.
 
 ### Runner class
 Default test runner class is `android.support.test.runner.AndroidJUnitRunner` but can be changed using the `runnerClass` option. 

--- a/docs/_docs/shell/shell-v2.md
+++ b/docs/_docs/shell/shell-v2.md
@@ -24,16 +24,20 @@ The response contains separate stdout and stderr as well as an exit code.
 
 ```kotlin
 data class ShellCommandResult(
-    val stdout: String,
-    val stderr: String,
+    val stdout: ByteArray,
+    val stderr: ByteArray,
     val exitCode: Int
 )
 ```
 
+If the output is UTF-8 encoded then you can use lazy properties `output` and `errorOutput` for conversion of bytes into a String,
+e.g. `result.output`.
+
 This request expects that the command returns immediately, or you don't want to stream the output.
 
 ## Streaming shell request
-Requires Feature.SHELL_V2 
+
+Requires Feature.SHELL_V2
 {: .label .label-yellow }
 
 You can execute arbitrary commands (`cat`, `tail -f`, etc) on the device using the `ChanneledShellCommandRequest`. Shell v2 brings in
@@ -47,7 +51,7 @@ launch {
     val stdioJob = launch(Dispatchers.IO) {
         stdio.send(
             ShellCommandInputChunk(
-                stdin = "cafebabe"
+                stdin = "cafebabe".toByteArray(Charsets.UTF_8)
             )
         )
 
@@ -62,8 +66,8 @@ launch {
     val stderrBuilder = StringBuilder()
     var exitCode = 1
     for (i in receiveChannel) {
-        i.stdout?.let { stdoutBuilder.append(it) }
-        i.stderr?.let { stderrBuilder.append(it) }
+        i.stdout?.let { stdoutBuilder.append(String(it, Charsets.UTF_8)) }
+        i.stderr?.let { stderrBuilder.append(String(it, Charsets.UTF_8)) }
         i.exitCode?.let { exitCode = it }
     }
     stdioJob.join()

--- a/docs/_docs/shell/shell.md
+++ b/docs/_docs/shell/shell.md
@@ -29,10 +29,12 @@ appends `;echo $?` to the end of the command and parses it automatically.
 
 ```kotlin
 data class ShellCommandResult(
-    val output: String,
+    val stdout: ByteArray,
     val exitCode: Int
 )
 ```
+
+If the output is UTF-8 encoded then you can use lazy property `output` for conversion of bytes into a String, e.g. `result.output`.
 
 This request expects that the command returns immediately, or you don't want to stream the output.
 

--- a/server/server-stub/src/main/kotlin/com/malinskiy/adam/server/stub/dsl/Session.kt
+++ b/server/server-stub/src/main/kotlin/com/malinskiy/adam/server/stub/dsl/Session.kt
@@ -39,6 +39,12 @@ class Session(val input: ServerReadChannel, val output: ServerWriteChannel) {
         return ShellV1SubSession(session = this)
     }
 
+    suspend fun expectShellV2(expected: () -> String): ShellV2SubSession {
+        val transportCmd = input.receiveCommand()
+        assertThat(transportCmd).isEqualTo("shell,v2,raw:${expected()}")
+        return ShellV2SubSession(session = this)
+    }
+
     suspend fun expectExec(expected: () -> String): ExecSubSession {
         val transportCmd = input.receiveCommand()
         assertThat(transportCmd).isEqualTo("exec:${expected()}")

--- a/server/server-stub/src/main/kotlin/com/malinskiy/adam/server/stub/dsl/ShellV2SubSession.kt
+++ b/server/server-stub/src/main/kotlin/com/malinskiy/adam/server/stub/dsl/ShellV2SubSession.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Anton Malinskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.malinskiy.adam.server.stub.dsl
+
+class ShellV2SubSession(private val session: Session) {
+    suspend fun accept(): ShellV2SubSession {
+        session.respondOkay()
+        return this
+    }
+
+    suspend fun respondStdout(stdout: String): ShellV2SubSession {
+        session.respondShellV2Stdout(stdout)
+        return this
+    }
+
+    suspend fun respondStderr(stdout: String): ShellV2SubSession {
+        session.respondShellV2Stderr(stdout)
+        return this
+    }
+
+    suspend fun respondExit(exitCode: Int): ShellV2SubSession {
+        session.respondShellV2Exit(exitCode)
+        return this
+    }
+
+    suspend fun reject(message: String) {
+        session.respondTransport(false, message)
+    }
+}


### PR DESCRIPTION
Fixes the issue with the latest Android 31+ and removes the assumption that output of shell requests is UTF-8 encoded

Note: breaking change