### PR TITLE
fix(adam): allow closing clients with socket factories

### DIFF
--- a/adam/src/main/kotlin/com/malinskiy/adam/AndroidDebugBridgeClient.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/AndroidDebugBridgeClient.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.Closeable
 import java.net.InetAddress
 import java.net.InetSocketAddress
 
@@ -39,7 +40,7 @@ class AndroidDebugBridgeClient(
     val port: Int,
     val host: InetAddress,
     val socketFactory: SocketFactory
-) {
+) : Closeable {
     private val socketAddress: InetSocketAddress = InetSocketAddress(host, port)
 
     suspend fun <T : Any?> execute(request: ComplexRequest<T>, serial: String? = null): T {
@@ -136,4 +137,9 @@ class AndroidDebugBridgeClient(
     companion object {
         private val log = AdamLogging.logger {}
     }
+
+    /**
+     * If you're reusing the socket factory across multiple clients then this will affect another client
+     */
+    override fun close() = socketFactory.close()
 }

--- a/adam/src/main/kotlin/com/malinskiy/adam/transport/SocketFactory.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/transport/SocketFactory.kt
@@ -16,9 +16,10 @@
 
 package com.malinskiy.adam.transport
 
+import java.io.Closeable
 import java.net.InetSocketAddress
 
-interface SocketFactory {
+interface SocketFactory : Closeable {
     suspend fun tcp(socketAddress: InetSocketAddress, connectTimeout: Long? = null, idleTimeout: Long? = null): Socket
-    fun close()
+    override fun close()
 }

--- a/adam/src/main/kotlin/com/malinskiy/adam/transport/vertx/VertxSocket.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/transport/vertx/VertxSocket.kt
@@ -193,7 +193,9 @@ class VertxSocket(private val socketAddress: SocketAddress, private val options:
                 if (read == -1) break
             }
         }
-        id?.let { vertx.undeploy(it) }
+        id?.let {
+            vertx.undeploy(it).await()
+        }
     }
 }
 


### PR DESCRIPTION
wait for vertice undeploy

solves the race with undeploy failed: already undeployed

related to #94