### PR TITLE
Grow buffer as needed when writing out socket data for shell commands.

### DIFF
--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
@@ -52,18 +52,18 @@ class ShellV2E2ETest {
         val receiveChannel = adbRule.adb.execute(ChanneledShellCommandRequest("cat", stdio), this, adbRule.deviceSerial)
         //Sending commands requires additional pool, otherwise we might deadlock
         val stdioJob = launch(Dispatchers.IO) {
-            stdio.send(
-                ShellCommandInputChunk(
-                    stdin = "cafebabe".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                )
-            )
+                    stdio.send(
+                            ShellCommandInputChunk(
+                                    stdin = "cafebabe".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
+                            )
+                    )
 
-            stdio.send(
+                    stdio.send(
                 ShellCommandInputChunk(
                     close = true
                 )
             )
-        }
+                }
 
         val stdoutBuilder = StringBuilder()
         val stderrBuilder = StringBuilder()
@@ -78,6 +78,12 @@ class ShellV2E2ETest {
         assertThat(stdoutBuilder.toString()).isEqualTo("cafebabe")
         assertThat(stderrBuilder.toString()).isEmpty()
         assertThat(exitCode).isEqualTo(0)
+    }
 
+    @Test
+    fun testChanneled_largeSocketBuffer_noIndexOutOfBoundsExceptionThrown() = runBlocking {
+        repeat(10) {    // May not always occur the first time. Attempt several.
+            adbRule.adb.execute(ShellCommandRequest("dumpsys window windows"), adbRule.deviceSerial)
+        }
     }
 }

--- a/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
+++ b/adam/src/integrationTest/kotlin/com/malinskiy/adam/integration/ShellV2E2ETest.kt
@@ -52,18 +52,18 @@ class ShellV2E2ETest {
         val receiveChannel = adbRule.adb.execute(ChanneledShellCommandRequest("cat", stdio), this, adbRule.deviceSerial)
         //Sending commands requires additional pool, otherwise we might deadlock
         val stdioJob = launch(Dispatchers.IO) {
-                    stdio.send(
-                            ShellCommandInputChunk(
-                                    stdin = "cafebabe".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
-                            )
-                    )
+            stdio.send(
+                ShellCommandInputChunk(
+                    stdin = "cafebabe".toByteArray(Const.DEFAULT_TRANSPORT_ENCODING)
+                )
+            )
 
-                    stdio.send(
+            stdio.send(
                 ShellCommandInputChunk(
                     close = true
                 )
             )
-                }
+        }
 
         val stdoutBuilder = StringBuilder()
         val stderrBuilder = StringBuilder()

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/SyncShellCommandRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/SyncShellCommandRequest.kt
@@ -56,7 +56,7 @@ abstract class SyncShellCommandRequest<T : Any?>(val cmd: String, target: Target
                         exitCode = socket.readByte().toInt()
                         break@loop
                     }
-                    
+
                     MessageType.STDIN, MessageType.CLOSE_STDIN, MessageType.WINDOW_SIZE_CHANGE, MessageType.INVALID -> {
                         throw RequestValidationException("Unsupported message $messageType")
                     }

--- a/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/SyncShellCommandRequest.kt
+++ b/adam/src/main/kotlin/com/malinskiy/adam/request/shell/v2/SyncShellCommandRequest.kt
@@ -16,6 +16,7 @@
 
 package com.malinskiy.adam.request.shell.v2
 
+import com.google.common.io.ByteArrayDataOutput
 import com.google.common.io.ByteStreams
 import com.malinskiy.adam.exception.RequestValidationException
 import com.malinskiy.adam.request.ComplexRequest
@@ -30,8 +31,9 @@ import com.malinskiy.adam.transport.withMaxPacketBuffer
 abstract class SyncShellCommandRequest<T : Any?>(val cmd: String, target: Target = NonSpecifiedTarget, socketIdleTimeout: Long? = null) :
     ComplexRequest<T>(target, socketIdleTimeout) {
 
-    private val stdoutBuilder = ByteStreams.newDataOutput()
-    private val stderrBuilder = ByteStreams.newDataOutput()
+    private val stdoutBuilder: ByteArrayDataOutput = ByteStreams.newDataOutput()
+    private val stderrBuilder: ByteArrayDataOutput = ByteStreams.newDataOutput()
+    private var buffer: ByteArray = ByteArray(nextDataSize(0))
     private var exitCode: Int = -1
 
     /**
@@ -42,20 +44,11 @@ abstract class SyncShellCommandRequest<T : Any?>(val cmd: String, target: Target
     override fun serialize() = createBaseRequest("shell,v2,raw:$cmd")
     override suspend fun readElement(socket: Socket): T {
         withMaxPacketBuffer {
-            val data = array()
             loop@ while (true) {
                 when (val messageType = MessageType.of(socket.readByte().toInt())) {
-                    MessageType.STDOUT -> {
-                        val length = socket.readIntLittleEndian()
-                        socket.readFully(data, 0, length)
-                        stdoutBuilder.write(data, 0, length)
-                    }
+                    MessageType.STDOUT -> stdoutBuilder.write(socket)
 
-                    MessageType.STDERR -> {
-                        val length = socket.readIntLittleEndian()
-                        socket.readFully(data, 0, length)
-                        stderrBuilder.write(data, 0, length)
-                    }
+                    MessageType.STDERR -> stderrBuilder.write(socket)
 
                     MessageType.EXIT -> {
                         //ignoredLength
@@ -63,7 +56,7 @@ abstract class SyncShellCommandRequest<T : Any?>(val cmd: String, target: Target
                         exitCode = socket.readByte().toInt()
                         break@loop
                     }
-
+                    
                     MessageType.STDIN, MessageType.CLOSE_STDIN, MessageType.WINDOW_SIZE_CHANGE, MessageType.INVALID -> {
                         throw RequestValidationException("Unsupported message $messageType")
                     }
@@ -78,5 +71,26 @@ abstract class SyncShellCommandRequest<T : Any?>(val cmd: String, target: Target
         )
 
         return convertResult(shellCommandResult)
+    }
+
+    private suspend fun ByteArrayDataOutput.write(socket: Socket): Unit {
+        val length = socket.readIntLittleEndian()
+        if (length > buffer.size) { // Grow buffer as needed.
+            buffer = ByteArray(nextDataSize(length))
+        }
+        socket.readFully(buffer, 0, length)
+        this.write(buffer, 0, length)
+    }
+
+    companion object {
+
+        /** Gets the next size for the data buffer in powers of two / exponential growth. */
+        private fun nextDataSize(requestedLength: Int): Int {
+            var size = 1 shl 14 // = 2^14 initial buffer; 8 and 16k are common in most frameworks
+            while (requestedLength > size) {
+                size = size shl 1
+            }
+            return size
+        }
     }
 }


### PR DESCRIPTION
Was encountering `IndexOutOfBoundsException`s when writing to the intermediate data buffer during a shell command request for `dumpsys window windows`.

Added a test for it and found the following call stack.

```
java.lang.IndexOutOfBoundsException
	at java.base/java.nio.ByteBuffer.wrap(ByteBuffer.java:410)
	at com.malinskiy.adam.transport.vertx.VertxSocket.readFully(VertxSocket.kt:144)
	at com.malinskiy.adam.request.shell.v2.SyncShellCommandRequest.readElement$suspendImpl(SyncShellCommandRequest.kt:53)
	at com.malinskiy.adam.request.shell.v2.SyncShellCommandRequest$readElement$1.invokeSuspend(SyncShellCommandRequest.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:280)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.malinskiy.adam.integration.ShellV2E2ETest.testChanneled2(ShellV2E2ETest.kt:88)
```

Debugged the shell command and found that the requested data length was larger than the buffer size of 16k.

```
readFully(buffer[.size = 16384], offset = 0, limit = 4)
readFully(buffer[.size = 16384], offset = 0, limit = 4)
readFully(buffer[.size = 16384], offset = 0, limit = 7988)
readFully(buffer[.size = 16384], offset = 0, limit = 7089)
readFully(buffer[.size = 16384], offset = 0, limit = 8192)
readFully(buffer[.size = 16384], offset = 0, limit = 6518)
readFully(buffer[.size = 16384], offset = 0, limit = 7792)
readFully(buffer[.size = 16384], offset = 0, limit = 8181)
readFully(buffer[.size = 16384], offset = 0, limit = 8168)
readFully(buffer[.size = 16384], offset = 0, limit = 8100)
readFully(buffer[.size = 16384], offset = 0, limit = 8086)
readFully(buffer[.size = 16384], offset = 0, limit = 8176)
readFully(buffer[.size = 16384], offset = 0, limit = 6280)
readFully(buffer[.size = 32768], offset = 0, limit = 37579)
readFully(buffer[.size = 16384], offset = 0, limit = 8)
```

This change will grow the buffer as needed by powers of 2. It would be nice if we could do away with having to roll our own adaptive buffer but it looks like this is a constraint of Vertx.

NOTE: `array()` is a deprecated Kotlin function. I think because it hides issues like these.